### PR TITLE
queue sub metric

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -59,6 +59,8 @@ Release Notes.
 - Fix flaky `file_snapshot` subtest in measure/stream/trace by waiting until every introduced mem part has been flushed to disk, instead of only checking the latest snapshot creator.
 - Fix deadlock when fodc-agent reconnects to fodc-proxy after a pod rotation.
 - Fix flaky `TestCollectWithPartialClosedSegments` by raising `SegmentIdleTimeout` so wall-clock variance on slow CI does not mark still-open segments as idle.
+- Fix FODC lifecycle cache poisoning where transient `InspectAll` failures were cached for 10 minutes and masked liaison recovery; raise FODC agent and proxy timeouts from 10s to 40s.
+- Fix FODC `/cluster/lifecycle` dropping zero-valued group fields (e.g. `replicas=0`, `close=false`) under `encoding/json` + `omitempty`; switch to `protojson` so all fields are emitted (nil nested messages serialize as `null`).
 
 ### Chores
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -31,6 +31,9 @@ Release Notes.
   - Add tombstone retention/GC (default 7 days, configurable via `--schema-server-tombstone-retention`) with a per-cache count cap to bound memory under bulk deletes.
   - Reject `Create` with `updated_at <= tombstone.delete_time` to prevent replayed creates from overwriting newer deletes.
   - Guard `pkg/schema/cache` against out-of-order `EventDelete` events; expose monotonic `LatestModRevision` watermark.
+- Schema consistency (Phase 2 in progress): cluster-wide barrier groundwork. Internal-only; no client-facing surface impact yet.
+  - Add `NodeSchemaStatusService` (`GetMaxRevision`, `GetKeyRevisions`, `GetAbsentKeys`) registered on every cluster member that holds a schema cache, so peer liaisons and data nodes can be probed identically by the upcoming barrier fan-out (#1108).
+  - Extend `queue.Client` with `NewNodeSchemaStatusClient(node)` so the barrier fan-out can borrow the existing tier1/tier2 connection pools instead of opening a parallel mesh.
 
 ### Bug Fixes
 

--- a/banyand/liaison/grpc/server.go
+++ b/banyand/liaison/grpc/server.go
@@ -39,6 +39,7 @@ import (
 
 	"github.com/apache/skywalking-banyandb/api/common"
 	bydbqlv1 "github.com/apache/skywalking-banyandb/api/proto/banyandb/bydbql/v1"
+	clusterv1 "github.com/apache/skywalking-banyandb/api/proto/banyandb/cluster/v1"
 	commonv1 "github.com/apache/skywalking-banyandb/api/proto/banyandb/common/v1"
 	databasev1 "github.com/apache/skywalking-banyandb/api/proto/banyandb/database/v1"
 	measurev1 "github.com/apache/skywalking-banyandb/api/proto/banyandb/measure/v1"
@@ -51,6 +52,7 @@ import (
 	"github.com/apache/skywalking-banyandb/banyand/liaison/pkg/auth"
 	"github.com/apache/skywalking-banyandb/banyand/metadata"
 	"github.com/apache/skywalking-banyandb/banyand/metadata/schema"
+	"github.com/apache/skywalking-banyandb/banyand/metadata/schema/property"
 	"github.com/apache/skywalking-banyandb/banyand/observability"
 	"github.com/apache/skywalking-banyandb/banyand/protector"
 	"github.com/apache/skywalking-banyandb/banyand/queue"
@@ -105,8 +107,9 @@ type server struct {
 	stopCh     chan struct{}
 	*indexRuleRegistryServer
 	*measureRegistryServer
-	streamSVC  *streamService
-	barrierSVC *barrierService
+	streamSVC     *streamService
+	barrierSVC    *barrierService
+	nodeStatusSVC *property.NodeSchemaStatusServer
 	*streamRegistryServer
 	measureSVC *measureService
 	bydbQLSVC  *bydbQLService
@@ -182,6 +185,7 @@ func NewServer(_ context.Context, tir1Client, tir2Client, broadcaster queue.Clie
 	}
 
 	var barrierSVC *barrierService
+	var nodeStatusSVC *property.NodeSchemaStatusServer
 	if svc, svcOk := schemaRegistry.(metadata.Service); svcOk {
 		barrierSVC = newBarrierService(func() barrierCacheReader {
 			inner := svc.SchemaRegistry()
@@ -194,15 +198,31 @@ func NewServer(_ context.Context, tir1Client, tir2Client, broadcaster queue.Clie
 			}
 			return bc
 		})
+		// Phase 2 Step 2.1: every cluster member with a schema cache exposes
+		// NodeSchemaStatusService so peer liaisons (Step 2.2 fan-out) can
+		// probe this liaison's cache identically to a data node. The receiving
+		// liaison probes itself in-process via the barrier above; remote peers
+		// reach this same cache through the gRPC service. Resolution is
+		// deferred to request time (closure) because the metadata service
+		// populates SchemaRegistry in PreRun, after NewServer has already
+		// run — capturing a snapshot here would skip registration permanently.
+		nodeStatusSVC = property.NewNodeSchemaStatusServerForRegistry(func() *property.SchemaRegistry {
+			reg, regOk := svc.SchemaRegistry().(*property.SchemaRegistry)
+			if !regOk {
+				return nil
+			}
+			return reg
+		})
 	}
 	s := &server{
-		omr:        omr,
-		streamSVC:  streamSVC,
-		measureSVC: measureSVC,
-		traceSVC:   traceSVC,
-		bydbQLSVC:  bydbQLSVC,
-		groupRepo:  gr,
-		barrierSVC: barrierSVC,
+		omr:           omr,
+		streamSVC:     streamSVC,
+		measureSVC:    measureSVC,
+		traceSVC:      traceSVC,
+		bydbQLSVC:     bydbQLSVC,
+		groupRepo:     gr,
+		barrierSVC:    barrierSVC,
+		nodeStatusSVC: nodeStatusSVC,
 		streamRegistryServer: &streamRegistryServer{
 			schemaRegistry: schemaRegistry,
 		},
@@ -508,6 +528,9 @@ func (s *server) Serve() run.StopNotify {
 	databasev1.RegisterNodeQueryServiceServer(s.ser, s)
 	if s.barrierSVC != nil {
 		schemav1.RegisterSchemaBarrierServiceServer(s.ser, s.barrierSVC)
+	}
+	if s.nodeStatusSVC != nil {
+		clusterv1.RegisterNodeSchemaStatusServiceServer(s.ser, s.nodeStatusSVC)
 	}
 	grpc_health_v1.RegisterHealthServer(s.ser, health.NewServer())
 

--- a/banyand/metadata/schema/property/cache.go
+++ b/banyand/metadata/schema/property/cache.go
@@ -194,6 +194,40 @@ func (c *schemaCache) GetKeyModRevision(propID string) (int64, bool) {
 	return entry.modRevision, true
 }
 
+// KeyRevision pairs a property ID with its observed mod_revision and a
+// presence flag. Returned by GetKeyRevisions in the same order the caller
+// supplied propIDs so the cluster RPC handler can join the result with its
+// proto SchemaKey input slice.
+type KeyRevision struct {
+	PropID      string
+	ModRevision int64
+	Present     bool
+}
+
+// GetKeyRevisions returns presence + mod_revision for each propID in a single
+// read-lock pass. It applies the same downstream-coherence gate as
+// GetKeyModRevision: an entry present in the cache map whose mod_revision
+// exceeds notifiedModRevision is reported as Present=false, ModRevision=0.
+// An empty input returns a non-nil empty slice.
+func (c *schemaCache) GetKeyRevisions(propIDs []string) []KeyRevision {
+	out := make([]KeyRevision, len(propIDs))
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	for i, pid := range propIDs {
+		out[i].PropID = pid
+		entry, ok := c.entries[pid]
+		if !ok {
+			continue
+		}
+		if entry.modRevision > c.notifiedModRevision {
+			continue
+		}
+		out[i].ModRevision = entry.modRevision
+		out[i].Present = true
+	}
+	return out
+}
+
 // AdvanceNotified pushes the downstream-handler watermark forward monotonically.
 // Callers must invoke this only after notifyHandlers returns for the given revision,
 // so downstream caches (groupRepo, entityRepo, pkg/schema.schemaRepo, …) are coherent

--- a/banyand/metadata/schema/property/converter.go
+++ b/banyand/metadata/schema/property/converter.go
@@ -149,6 +149,47 @@ func KindFromString(kindStr string) (schema.Kind, error) {
 	return 0, fmt.Errorf("unknown kind string: %s", kindStr)
 }
 
+// kindFromProtoString maps the proto-style kind string from SchemaKey
+// (underscore_case for compound kinds) to the corresponding schema.Kind. The
+// proto schema keeps SchemaKey.kind on a fixed set of values: "stream",
+// "measure", "trace", "property", "index_rule", "index_rule_binding",
+// "group", "top_n_aggregation". An unknown value returns 0 and the caller
+// should treat the SchemaKey as referring to no live entry.
+func kindFromProtoString(protoKind string) schema.Kind {
+	switch protoKind {
+	case "stream":
+		return schema.KindStream
+	case "measure":
+		return schema.KindMeasure
+	case "trace":
+		return schema.KindTrace
+	case "property":
+		return schema.KindProperty
+	case "index_rule":
+		return schema.KindIndexRule
+	case "index_rule_binding":
+		return schema.KindIndexRuleBinding
+	case "group":
+		return schema.KindGroup
+	case "top_n_aggregation":
+		return schema.KindTopNAggregation
+	default:
+		return 0
+	}
+}
+
+// BuildPropertyIDFromSchemaKey converts a SchemaKey from the cluster
+// node-status proto into the property-ID string used internally by the
+// schema cache. Returns an empty string when the kind is unrecognized so
+// the caller can short-circuit instead of looking up a malformed propID.
+func BuildPropertyIDFromSchemaKey(key *schemav1.SchemaKey) string {
+	kind := kindFromProtoString(key.GetKind())
+	if kind == 0 {
+		return ""
+	}
+	return BuildPropertyID(kind, &commonv1.Metadata{Group: key.GetGroup(), Name: key.GetName()})
+}
+
 // ParsedTags holds pre-extracted tag values from a property.
 type ParsedTags struct {
 	Group     string

--- a/banyand/metadata/schema/property/node_status.go
+++ b/banyand/metadata/schema/property/node_status.go
@@ -1,0 +1,185 @@
+// Licensed to Apache Software Foundation (ASF) under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Apache Software Foundation (ASF) licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package property
+
+import (
+	"context"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	clusterv1 "github.com/apache/skywalking-banyandb/api/proto/banyandb/cluster/v1"
+	schemav1 "github.com/apache/skywalking-banyandb/api/proto/banyandb/schema/v1"
+)
+
+// nodeStatusMaxKeys caps the per-request key count to match SchemaBarrierService
+// (barrierMaxKeys in banyand/liaison/grpc/barrier.go). The proto leaves this
+// uncapped so chunking is the caller's responsibility, but the server still
+// enforces the same bound the SchemaBarrierService does so a misbehaving peer
+// cannot allocate unbounded memory.
+const nodeStatusMaxKeys = 10000
+
+// NodeSchemaStatusServer implements clusterv1.NodeSchemaStatusServiceServer
+// against a local SchemaRegistry cache. The same implementation runs on every
+// cluster member that holds a schema cache: liaisons (Role_ROLE_LIAISON) and
+// data nodes (Role_ROLE_DATA). The "Node" prefix in the service name is a
+// misnomer inherited from the original proto draft — treat the service as
+// "cluster-member schema status" regardless of the role serving it.
+//
+// The cache the server reads (the SchemaRegistry's schemaCache) is the same
+// one downstream consumers (pkg/schema.schemaRepo, groupRepo, entityRepo)
+// observe through the property watch loop. The schemaCache.notifiedModRevision
+// watermark only advances after every registered handler has processed the
+// relevant event, so a positive answer from this server (Present=true,
+// rev=R) implies every downstream cache has also observed R. This is the
+// load-bearing prerequisite for the Phase 2 cluster barrier — without it,
+// the barrier would confirm a cache the data-node query executor never reads.
+type NodeSchemaStatusServer struct {
+	clusterv1.UnimplementedNodeSchemaStatusServiceServer
+	cacheProvider func() *schemaCache
+}
+
+// NewNodeSchemaStatusServer wires the server to a cache provider. The
+// provider is called per request so the server tolerates SchemaRegistry
+// initialisation racing the gRPC server boot — an early call simply gets a
+// nil cache and returns zero-valued results, which liaison-side fan-out
+// treats as "node not yet ready, retry on the next backoff iteration"
+// rather than a hard error.
+func NewNodeSchemaStatusServer(cacheProvider func() *schemaCache) *NodeSchemaStatusServer {
+	return &NodeSchemaStatusServer{cacheProvider: cacheProvider}
+}
+
+// NewNodeSchemaStatusServerForRegistry wires the server through a registry
+// provider resolved per request. Construction-time wiring (which happens
+// before the metadata service's PreRun has populated the registry) would
+// otherwise capture a nil snapshot and skip registration permanently. The
+// provider lets the server tolerate a still-initializing registry the same
+// way the barrierSVC closure in banyand/liaison/grpc/server.go does — a nil
+// registry surfaces through cacheProvider as a nil schemaCache and the
+// fail-closed nil-cache contract takes over.
+func NewNodeSchemaStatusServerForRegistry(provider func() *SchemaRegistry) *NodeSchemaStatusServer {
+	return &NodeSchemaStatusServer{
+		cacheProvider: func() *schemaCache {
+			if provider == nil {
+				return nil
+			}
+			reg := provider()
+			if reg == nil {
+				return nil
+			}
+			return reg.cache
+		},
+	}
+}
+
+// GetMaxRevision returns the highest mod_revision currently observed by the
+// node's local schema cache. When the cache is not yet initialized the
+// response carries 0, which the liaison's barrier loop interprets as
+// "node not yet caught up" and continues polling.
+func (s *NodeSchemaStatusServer) GetMaxRevision(_ context.Context, _ *clusterv1.GetMaxRevisionRequest) (*clusterv1.GetMaxRevisionResponse, error) {
+	c := s.cacheProvider()
+	if c == nil {
+		return &clusterv1.GetMaxRevisionResponse{}, nil
+	}
+	return &clusterv1.GetMaxRevisionResponse{MaxModRevision: c.GetMaxModRevision()}, nil
+}
+
+// GetKeyRevisions returns per-key (mod_revision, present) pairs in the same
+// order the caller supplied keys. A key referencing a group the node has
+// not observed maps to mod_revision=0, present=false — the call does not
+// error on missing groups so the liaison can treat group-not-yet-registered
+// as a normal laggard rather than a server fault.
+//
+// An empty request is valid and produces an empty response.
+func (s *NodeSchemaStatusServer) GetKeyRevisions(_ context.Context, req *clusterv1.GetKeyRevisionsRequest) (*clusterv1.GetKeyRevisionsResponse, error) {
+	keys := req.GetKeys()
+	if len(keys) > nodeStatusMaxKeys {
+		return nil, status.Errorf(codes.InvalidArgument, "too many keys: max=%d", nodeStatusMaxKeys)
+	}
+	resp := &clusterv1.GetKeyRevisionsResponse{
+		Revisions: make([]*clusterv1.KeyRevision, len(keys)),
+	}
+	for i, key := range keys {
+		resp.Revisions[i] = &clusterv1.KeyRevision{Key: key}
+	}
+	c := s.cacheProvider()
+	if c == nil || len(keys) == 0 {
+		return resp, nil
+	}
+	propIDs := schemaKeysToPropIDs(keys)
+	statuses := c.GetKeyRevisions(propIDs)
+	for i, keyStatus := range statuses {
+		resp.Revisions[i].ModRevision = keyStatus.ModRevision
+		resp.Revisions[i].Present = keyStatus.Present
+	}
+	return resp, nil
+}
+
+// GetAbsentKeys partitions the requested keys into "absent" (i.e. not in the
+// node's live cache or pending downstream notification) and "still_present".
+// A SchemaKey with an unknown kind value is reported in absent_keys without
+// erroring so the caller can rely on the partition adding up to the input.
+func (s *NodeSchemaStatusServer) GetAbsentKeys(_ context.Context, req *clusterv1.GetAbsentKeysRequest) (*clusterv1.GetAbsentKeysResponse, error) {
+	keys := req.GetKeys()
+	if len(keys) > nodeStatusMaxKeys {
+		return nil, status.Errorf(codes.InvalidArgument, "too many keys: max=%d", nodeStatusMaxKeys)
+	}
+	resp := &clusterv1.GetAbsentKeysResponse{}
+	if len(keys) == 0 {
+		return resp, nil
+	}
+	c := s.cacheProvider()
+	if c == nil {
+		// Cache not yet initialized — the node has not observed any schema
+		// state, so it cannot claim deletion has been applied. Report every
+		// key as still present so the liaison's AwaitSchemaDeleted barrier
+		// keeps polling until the cache is online. Mirrors the Phase 1
+		// collectPresentKeys nil-cache contract in
+		// banyand/liaison/grpc/barrier.go.
+		resp.StillPresentKeys = append([]*schemav1.SchemaKey(nil), keys...)
+		return resp, nil
+	}
+	propIDs := schemaKeysToPropIDs(keys)
+	// One read-lock pass over the cache; an empty propID (unknown kind) maps
+	// to Present=false in c.GetKeyRevisions because c.entries[""] never
+	// matches, which is the same "absent" partition the proto requires.
+	statuses := c.GetKeyRevisions(propIDs)
+	for i, keyStatus := range statuses {
+		if keyStatus.Present {
+			resp.StillPresentKeys = append(resp.StillPresentKeys, keys[i])
+			continue
+		}
+		resp.AbsentKeys = append(resp.AbsentKeys, keys[i])
+	}
+	return resp, nil
+}
+
+// schemaKeysToPropIDs converts a slice of SchemaKey messages into the
+// internal propID strings used by the schema cache. Keys with unknown kind
+// strings produce an empty propID at the corresponding index; callers may
+// pass empty propIDs straight to schemaCache.GetKeyRevisions, which reports
+// them as Present=false (the cache map never holds an entry under "").
+// This matches the proto contract: an unknown kind is "absent from this
+// node's perspective" rather than a parse error.
+func schemaKeysToPropIDs(keys []*schemav1.SchemaKey) []string {
+	out := make([]string, len(keys))
+	for i, key := range keys {
+		out[i] = BuildPropertyIDFromSchemaKey(key)
+	}
+	return out
+}

--- a/banyand/metadata/schema/property/node_status_test.go
+++ b/banyand/metadata/schema/property/node_status_test.go
@@ -1,0 +1,301 @@
+// Licensed to Apache Software Foundation (ASF) under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Apache Software Foundation (ASF) licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package property
+
+import (
+	"context"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	clusterv1 "github.com/apache/skywalking-banyandb/api/proto/banyandb/cluster/v1"
+	schemav1 "github.com/apache/skywalking-banyandb/api/proto/banyandb/schema/v1"
+	"github.com/apache/skywalking-banyandb/banyand/metadata/schema"
+)
+
+// nodeStatusFixture builds a NodeSchemaStatusServer backed by a fresh schemaCache
+// pre-loaded with the supplied entries. The notifiedModRevision watermark is
+// advanced to the highest entry revision so every entry is downstream-coherent
+// (the production path advances the watermark only after handlers process the
+// event; tests bypass the handler chain by setting it directly).
+func nodeStatusFixture(t *testing.T, entries map[string]*cacheEntry) *NodeSchemaStatusServer {
+	t.Helper()
+	c := newSchemaCache()
+	var maxRev int64
+	for propID, entry := range entries {
+		c.entries[propID] = entry
+		if entry.modRevision > maxRev {
+			maxRev = entry.modRevision
+		}
+		if entry.latestUpdateAt > c.latestUpdateAt {
+			c.latestUpdateAt = entry.latestUpdateAt
+		}
+	}
+	c.notifiedModRevision = maxRev
+	return NewNodeSchemaStatusServer(func() *schemaCache { return c })
+}
+
+const testGroup = "g1"
+
+func makeEntry(kind schema.Kind, name string, rev int64) (string, *cacheEntry) {
+	propID := kind.String() + "_"
+	if kind == schema.KindGroup {
+		propID += name
+	} else {
+		propID += testGroup + "/" + name
+	}
+	return propID, &cacheEntry{
+		group:          testGroup,
+		name:           name,
+		kind:           kind,
+		modRevision:    rev,
+		latestUpdateAt: rev,
+	}
+}
+
+func TestGetMaxRevision_ReflectsLatestApply(t *testing.T) {
+	id, entry := makeEntry(schema.KindMeasure, "m1", 42)
+	srv := nodeStatusFixture(t, map[string]*cacheEntry{id: entry})
+
+	resp, err := srv.GetMaxRevision(context.Background(), &clusterv1.GetMaxRevisionRequest{})
+	require.NoError(t, err)
+	assert.Equal(t, int64(42), resp.GetMaxModRevision())
+}
+
+func TestGetMaxRevision_UnchangedByQuery(t *testing.T) {
+	id, entry := makeEntry(schema.KindStream, "s1", 100)
+	srv := nodeStatusFixture(t, map[string]*cacheEntry{id: entry})
+
+	first, err := srv.GetMaxRevision(context.Background(), &clusterv1.GetMaxRevisionRequest{})
+	require.NoError(t, err)
+	second, err := srv.GetMaxRevision(context.Background(), &clusterv1.GetMaxRevisionRequest{})
+	require.NoError(t, err)
+	third, err := srv.GetMaxRevision(context.Background(), &clusterv1.GetMaxRevisionRequest{})
+	require.NoError(t, err)
+
+	assert.Equal(t, first.GetMaxModRevision(), second.GetMaxModRevision())
+	assert.Equal(t, second.GetMaxModRevision(), third.GetMaxModRevision())
+}
+
+func TestGetMaxRevision_NilCache_ReturnsZero(t *testing.T) {
+	srv := NewNodeSchemaStatusServer(func() *schemaCache { return nil })
+
+	resp, err := srv.GetMaxRevision(context.Background(), &clusterv1.GetMaxRevisionRequest{})
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), resp.GetMaxModRevision())
+}
+
+func TestGetKeyRevisions_PresentAndAbsent(t *testing.T) {
+	idMeasure, entryMeasure := makeEntry(schema.KindMeasure, "m1", 50)
+	idStream, entryStream := makeEntry(schema.KindStream, "s1", 70)
+	srv := nodeStatusFixture(t, map[string]*cacheEntry{
+		idMeasure: entryMeasure,
+		idStream:  entryStream,
+	})
+
+	req := &clusterv1.GetKeyRevisionsRequest{
+		Keys: []*schemav1.SchemaKey{
+			{Kind: "measure", Group: "g1", Name: "m1"},     // present, rev 50
+			{Kind: "measure", Group: "g1", Name: "absent"}, // absent
+			{Kind: "stream", Group: "g1", Name: "s1"},      // present, rev 70
+			{Kind: "trace", Group: "g1", Name: "absent"},   // absent (group with no entries)
+		},
+	}
+
+	resp, err := srv.GetKeyRevisions(context.Background(), req)
+	require.NoError(t, err)
+	require.Len(t, resp.GetRevisions(), 4, "response preserves input order and length")
+
+	assert.True(t, resp.Revisions[0].GetPresent())
+	assert.Equal(t, int64(50), resp.Revisions[0].GetModRevision())
+	assert.Equal(t, "m1", resp.Revisions[0].GetKey().GetName())
+
+	assert.False(t, resp.Revisions[1].GetPresent())
+	assert.Equal(t, int64(0), resp.Revisions[1].GetModRevision())
+
+	assert.True(t, resp.Revisions[2].GetPresent())
+	assert.Equal(t, int64(70), resp.Revisions[2].GetModRevision())
+
+	assert.False(t, resp.Revisions[3].GetPresent())
+	assert.Equal(t, int64(0), resp.Revisions[3].GetModRevision())
+}
+
+func TestGetKeyRevisions_UnknownKind_ReportedAbsent(t *testing.T) {
+	srv := nodeStatusFixture(t, map[string]*cacheEntry{})
+
+	req := &clusterv1.GetKeyRevisionsRequest{
+		Keys: []*schemav1.SchemaKey{
+			{Kind: "not_a_real_kind", Group: "g1", Name: "x"},
+		},
+	}
+
+	resp, err := srv.GetKeyRevisions(context.Background(), req)
+	require.NoError(t, err)
+	require.Len(t, resp.GetRevisions(), 1)
+	assert.False(t, resp.Revisions[0].GetPresent())
+}
+
+func TestGetKeyRevisions_NotYetNotified_ReportedAbsent(t *testing.T) {
+	// Entry exists in cache map but its mod_revision exceeds notifiedModRevision —
+	// downstream handlers have not yet processed it. Per the gate semantics in
+	// GetKeyModRevision, the server must report it as not present.
+	c := newSchemaCache()
+	id, entry := makeEntry(schema.KindMeasure, "m1", 100)
+	c.entries[id] = entry
+	c.notifiedModRevision = 50 // below entry's rev
+	srv := NewNodeSchemaStatusServer(func() *schemaCache { return c })
+
+	req := &clusterv1.GetKeyRevisionsRequest{
+		Keys: []*schemav1.SchemaKey{
+			{Kind: "measure", Group: "g1", Name: "m1"},
+		},
+	}
+
+	resp, err := srv.GetKeyRevisions(context.Background(), req)
+	require.NoError(t, err)
+	require.Len(t, resp.GetRevisions(), 1)
+	assert.False(t, resp.Revisions[0].GetPresent(),
+		"entry not yet notified to downstream handlers must report Present=false")
+	assert.Equal(t, int64(0), resp.Revisions[0].GetModRevision())
+}
+
+func TestGetAbsentKeys_PostDelete(t *testing.T) {
+	// Two entries exist; one will be removed; the third reference is to an
+	// entry that never existed. Expectation: the deleted key and the
+	// never-existed key end up in absent_keys; the surviving key in
+	// still_present_keys.
+	idAlive, entryAlive := makeEntry(schema.KindMeasure, "alive", 30)
+	idDead, entryDead := makeEntry(schema.KindMeasure, "dead", 40)
+	c := newSchemaCache()
+	c.entries[idAlive] = entryAlive
+	c.entries[idDead] = entryDead
+	c.notifiedModRevision = 40
+	c.latestUpdateAt = 40
+	// Simulate a delete event for the "dead" key at a higher revision.
+	require.True(t, c.Delete(idDead, 50))
+	c.AdvanceNotified(50)
+	srv := NewNodeSchemaStatusServer(func() *schemaCache { return c })
+
+	req := &clusterv1.GetAbsentKeysRequest{
+		Keys: []*schemav1.SchemaKey{
+			{Kind: "measure", Group: "g1", Name: "alive"},
+			{Kind: "measure", Group: "g1", Name: "dead"},
+			{Kind: "measure", Group: "g1", Name: "never"},
+		},
+	}
+
+	resp, err := srv.GetAbsentKeys(context.Background(), req)
+	require.NoError(t, err)
+	require.Len(t, resp.GetStillPresentKeys(), 1)
+	assert.Equal(t, "alive", resp.GetStillPresentKeys()[0].GetName())
+
+	require.Len(t, resp.GetAbsentKeys(), 2)
+	absentNames := []string{
+		resp.GetAbsentKeys()[0].GetName(),
+		resp.GetAbsentKeys()[1].GetName(),
+	}
+	assert.Contains(t, absentNames, "dead")
+	assert.Contains(t, absentNames, "never")
+}
+
+func TestGetAbsentKeys_NilCache_AllStillPresent(t *testing.T) {
+	// A nil cache means the node has not observed any schema state. The node
+	// must therefore report every requested key as still-present so the
+	// liaison's AwaitSchemaDeleted barrier keeps polling rather than falsely
+	// concluding deletion has been applied. Mirrors the Phase 1 collectPresentKeys
+	// nil-cache contract in banyand/liaison/grpc/barrier.go.
+	srv := NewNodeSchemaStatusServer(func() *schemaCache { return nil })
+
+	req := &clusterv1.GetAbsentKeysRequest{
+		Keys: []*schemav1.SchemaKey{
+			{Kind: "measure", Group: "g1", Name: "x"},
+			{Kind: "stream", Group: "g1", Name: "y"},
+		},
+	}
+
+	resp, err := srv.GetAbsentKeys(context.Background(), req)
+	require.NoError(t, err)
+	assert.Len(t, resp.GetStillPresentKeys(), 2,
+		"nil cache reports every requested key as still-present so the liaison barrier keeps polling")
+	assert.Empty(t, resp.GetAbsentKeys())
+}
+
+func TestGetKeyRevisions_OverLimit_RejectsWithInvalidArgument(t *testing.T) {
+	srv := nodeStatusFixture(t, map[string]*cacheEntry{})
+	keys := make([]*schemav1.SchemaKey, nodeStatusMaxKeys+1)
+	for i := range keys {
+		keys[i] = &schemav1.SchemaKey{Kind: "measure", Group: "g1", Name: strconv.Itoa(i)}
+	}
+
+	resp, err := srv.GetKeyRevisions(context.Background(), &clusterv1.GetKeyRevisionsRequest{Keys: keys})
+	require.Error(t, err)
+	assert.Nil(t, resp)
+	assert.Equal(t, codes.InvalidArgument, status.Code(err))
+}
+
+func TestGetAbsentKeys_OverLimit_RejectsWithInvalidArgument(t *testing.T) {
+	srv := nodeStatusFixture(t, map[string]*cacheEntry{})
+	keys := make([]*schemav1.SchemaKey, nodeStatusMaxKeys+1)
+	for i := range keys {
+		keys[i] = &schemav1.SchemaKey{Kind: "measure", Group: "g1", Name: strconv.Itoa(i)}
+	}
+
+	resp, err := srv.GetAbsentKeys(context.Background(), &clusterv1.GetAbsentKeysRequest{Keys: keys})
+	require.Error(t, err)
+	assert.Nil(t, resp)
+	assert.Equal(t, codes.InvalidArgument, status.Code(err))
+}
+
+func TestGetKeyRevisions_ChunkedAtLimit(t *testing.T) {
+	// Server accepts a request well above the typical 1000-key chunk size used
+	// by the liaison fan-out. The proto does not enforce a hard cap on
+	// GetKeyRevisions — chunking is the caller's responsibility — so the server
+	// must process whatever it is handed without truncation or error.
+	const total = 1500
+	entries := make(map[string]*cacheEntry, total)
+	keys := make([]*schemav1.SchemaKey, total)
+	for i := range total {
+		name := "m" + strconv.Itoa(i)
+		id, entry := makeEntry(schema.KindMeasure, name, int64(i+1))
+		entries[id] = entry
+		keys[i] = &schemav1.SchemaKey{Kind: "measure", Group: "g1", Name: name}
+	}
+	srv := nodeStatusFixture(t, entries)
+
+	resp, err := srv.GetKeyRevisions(context.Background(), &clusterv1.GetKeyRevisionsRequest{Keys: keys})
+	require.NoError(t, err)
+	require.Len(t, resp.GetRevisions(), total)
+	for i := range total {
+		assert.True(t, resp.Revisions[i].GetPresent(), "key %d must be present", i)
+		assert.Equal(t, int64(i+1), resp.Revisions[i].GetModRevision(),
+			"key %d carries its assigned revision", i)
+	}
+}
+
+func TestGetKeyRevisions_EmptyRequest_ReturnsEmpty(t *testing.T) {
+	srv := nodeStatusFixture(t, map[string]*cacheEntry{})
+
+	resp, err := srv.GetKeyRevisions(context.Background(), &clusterv1.GetKeyRevisionsRequest{})
+	require.NoError(t, err)
+	assert.Empty(t, resp.GetRevisions(),
+		"empty key list yields empty response without panic")
+}

--- a/banyand/queue/local.go
+++ b/banyand/queue/local.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"github.com/apache/skywalking-banyandb/api/common"
+	clusterv1 "github.com/apache/skywalking-banyandb/api/proto/banyandb/cluster/v1"
 	databasev1 "github.com/apache/skywalking-banyandb/api/proto/banyandb/database/v1"
 	"github.com/apache/skywalking-banyandb/banyand/liaison/grpc/route"
 	"github.com/apache/skywalking-banyandb/banyand/metadata"
@@ -177,6 +178,13 @@ func (l *local) RegisterChunkedSyncHandler(_ bus.Topic, _ ChunkedSyncHandler) {
 
 func (l *local) NewChunkedSyncClient(node string, _ uint32) (ChunkedSyncClient, error) {
 	return &localChunkedSyncClient{local: l.local, node: node}, nil
+}
+
+// NewNodeSchemaStatusClient returns ErrNotImplemented because the standalone
+// pipeline has no peer to dial. The cluster barrier fan-out (Step 2.2) treats
+// this sentinel as a signal to degrade to in-process self-probing.
+func (*local) NewNodeSchemaStatusClient(_ string) (clusterv1.NodeSchemaStatusServiceClient, error) {
+	return nil, ErrNotImplemented
 }
 
 type localChunkedSyncClient struct {

--- a/banyand/queue/pub/pub.go
+++ b/banyand/queue/pub/pub.go
@@ -564,3 +564,17 @@ func (p *pub) NewChunkedSyncClientWithConfig(node string, config *ChunkedSyncCli
 func (p *pub) HealthyNodes() []string {
 	return p.connMgr.ActiveNames()
 }
+
+// NewNodeSchemaStatusClient borrows the underlying *grpc.ClientConn from the
+// connection pool and wraps it as a clusterv1.NodeSchemaStatusServiceClient
+// so the cluster-barrier fan-out (Step 2.2) can probe peer caches without
+// opening parallel connections. The returned client shares the conn's HTTP/2
+// streams with normal queue traffic; per-RPC contexts carry their own
+// deadlines.
+func (p *pub) NewNodeSchemaStatusClient(node string) (clusterv1.NodeSchemaStatusServiceClient, error) {
+	c, ok := p.connMgr.GetClient(node)
+	if !ok {
+		return nil, fmt.Errorf("no active client for node %s", node)
+	}
+	return clusterv1.NewNodeSchemaStatusServiceClient(c.conn), nil
+}

--- a/banyand/queue/queue.go
+++ b/banyand/queue/queue.go
@@ -19,6 +19,7 @@ package queue
 
 import (
 	"context"
+	"errors"
 	"sync"
 	"time"
 
@@ -31,6 +32,13 @@ import (
 	"github.com/apache/skywalking-banyandb/pkg/fs"
 	"github.com/apache/skywalking-banyandb/pkg/run"
 )
+
+// ErrNotImplemented is returned by Client implementations that have no peers
+// to dial — notably the standalone local pipeline. Callers (e.g. the cluster
+// barrier fan-out) treat this sentinel as "no peer to probe; skip" rather
+// than as a hard failure, so the standalone path degrades to in-process
+// self-probing without a special-cased branch in the caller.
+var ErrNotImplemented = errors.New("not implemented")
 
 // Queue builds a data transmission tunnel between subscribers and publishers.
 //
@@ -51,6 +59,12 @@ type Client interface {
 	route.TableProvider
 	NewBatchPublisher(timeout time.Duration) BatchPublisher
 	NewChunkedSyncClient(node string, chunkSize uint32) (ChunkedSyncClient, error)
+	// NewNodeSchemaStatusClient returns a client for the cluster.v1
+	// NodeSchemaStatusService against the named node, sharing the underlying
+	// *grpc.ClientConn from this queue client's existing connection pool.
+	// The standalone local pipeline returns ErrNotImplemented so callers can
+	// treat it as "no peer to probe" without a type-switch.
+	NewNodeSchemaStatusClient(node string) (clusterv1.NodeSchemaStatusServiceClient, error)
 	Register(bus.Topic, schema.EventHandler)
 	OnAddOrUpdate(md schema.Metadata)
 	GracefulStop()

--- a/banyand/queue/sub/chunked_sync.go
+++ b/banyand/queue/sub/chunked_sync.go
@@ -121,17 +121,33 @@ type partProgress struct {
 	completed     bool
 }
 
+// releaseMetrics releases the gauges held by this session.
+func (s *syncSession) releaseMetrics(m *metrics) {
+	if m == nil || s.completed {
+		return
+	}
+	m.activeSyncSessions.Add(-1, s.metadata.Topic)
+	if s.chunkBuffer != nil {
+		if n := len(s.chunkBuffer.chunks); n > 0 {
+			m.reorderBuffered.Add(-float64(n), s.metadata.Topic)
+		}
+	}
+	s.completed = true
+}
+
 // SyncPart implements clusterv1.ChunkedSyncServiceServer.
 func (s *server) SyncPart(stream clusterv1.ChunkedSyncService_SyncPartServer) error {
 	ctx := stream.Context()
 	var currentSession *syncSession
 	var sessionID string
 	defer func() {
-		if currentSession != nil {
-			if currentSession.partCtx != nil {
-				if closeErr := currentSession.partCtx.Close(); closeErr != nil {
-					s.log.Error().Err(closeErr).Str("session_id", currentSession.sessionID).Msg("failed to close session partCtx")
-				}
+		if currentSession == nil {
+			return
+		}
+		currentSession.releaseMetrics(s.metrics)
+		if currentSession.partCtx != nil {
+			if closeErr := currentSession.partCtx.Close(); closeErr != nil {
+				s.log.Error().Err(closeErr).Str("session_id", currentSession.sessionID).Msg("failed to close session partCtx")
 			}
 		}
 	}()
@@ -155,34 +171,7 @@ func (s *server) SyncPart(stream clusterv1.ChunkedSyncService_SyncPartServer) er
 		sessionID = req.SessionId
 
 		if req.GetMetadata() != nil {
-			if currentSession != nil {
-				if currentSession.partCtx != nil {
-					if currentSession.partCtx.Handler != nil {
-						if finishErr := currentSession.partCtx.Handler.FinishSync(); finishErr != nil {
-							s.updateChunkOrderMetrics("finish_sync_err", currentSession.metadata.Topic)
-							s.log.Error().Err(finishErr).Str("session_id", currentSession.sessionID).Msg("failed to finish sync for previous session")
-						}
-						if closeErr := currentSession.partCtx.Close(); closeErr != nil {
-							s.log.Error().Err(closeErr).Str("session_id", currentSession.sessionID).Msg("failed to close previous session partCtx")
-						}
-					} else if closeErr := currentSession.partCtx.Close(); closeErr != nil {
-						s.log.Error().Err(closeErr).Str("session_id", currentSession.sessionID).Msg("failed to close previous session partCtx")
-					}
-				}
-			}
-			currentSession = &syncSession{
-				sessionID:      sessionID,
-				metadata:       req.GetMetadata(),
-				startTime:      time.Now(),
-				chunksReceived: 0,
-				partsProgress:  make(map[int]*partProgress),
-			}
-			if dl := s.log.Debug(); dl.Enabled() {
-				dl.Str("session_id", sessionID).
-					Str("topic", req.GetMetadata().Topic).
-					Uint32("total_parts", req.GetMetadata().TotalParts).
-					Msg("started chunked sync session")
-			}
+			currentSession = s.startOrSwitchSession(sessionID, req, currentSession)
 		}
 
 		if currentSession == nil {
@@ -202,6 +191,47 @@ func (s *server) SyncPart(stream clusterv1.ChunkedSyncService_SyncPartServer) er
 	}
 
 	return nil
+}
+
+func (s *server) startOrSwitchSession(sessionID string, req *clusterv1.SyncPartRequest, previousSession *syncSession) *syncSession {
+	if previousSession != nil {
+		s.cleanupPreviousSession(previousSession)
+	}
+
+	newSession := &syncSession{
+		sessionID:      sessionID,
+		metadata:       req.GetMetadata(),
+		startTime:      time.Now(),
+		chunksReceived: 0,
+		partsProgress:  make(map[int]*partProgress),
+	}
+	if s.metrics != nil {
+		s.metrics.activeSyncSessions.Add(1, newSession.metadata.Topic)
+	}
+	if dl := s.log.Debug(); dl.Enabled() {
+		dl.Str("session_id", sessionID).
+			Str("topic", req.GetMetadata().Topic).
+			Uint32("total_parts", req.GetMetadata().TotalParts).
+			Msg("started chunked sync session")
+	}
+	return newSession
+}
+
+func (s *server) cleanupPreviousSession(previousSession *syncSession) {
+	previousSession.releaseMetrics(s.metrics)
+
+	if previousSession.partCtx == nil {
+		return
+	}
+	if previousSession.partCtx.Handler != nil {
+		if finishErr := previousSession.partCtx.Handler.FinishSync(); finishErr != nil {
+			s.updateChunkOrderMetrics("finish_sync_err", previousSession.metadata.Topic)
+			s.log.Error().Err(finishErr).Str("session_id", previousSession.sessionID).Msg("failed to finish sync for previous session")
+		}
+	}
+	if closeErr := previousSession.partCtx.Close(); closeErr != nil {
+		s.log.Error().Err(closeErr).Str("session_id", previousSession.sessionID).Msg("failed to close previous session partCtx")
+	}
 }
 
 func (s *server) processChunk(stream clusterv1.ChunkedSyncService_SyncPartServer, session *syncSession, req *clusterv1.SyncPartRequest) error {
@@ -306,7 +336,9 @@ func (s *server) processChunkWithReordering(stream clusterv1.ChunkedSyncService_
 				Msg("buffered out-of-order chunk")
 		}
 		s.updateChunkOrderMetrics("chunk_buffered", session.metadata.Topic)
-
+		if s.metrics != nil {
+			s.metrics.reorderBuffered.Add(1, session.metadata.Topic)
+		}
 		return s.sendResponse(stream, req, clusterv1.SyncStatus_SYNC_STATUS_CHUNK_RECEIVED,
 			fmt.Sprintf("chunk %d buffered (waiting for %d)", req.ChunkIndex, buffer.expectedIndex), nil)
 	}
@@ -414,6 +446,9 @@ func (s *server) processBufferedChunks(stream clusterv1.ChunkedSyncService_SyncP
 	for {
 		if chunk, exists := buffer.chunks[buffer.expectedIndex]; exists {
 			delete(buffer.chunks, buffer.expectedIndex)
+			if s.metrics != nil {
+				s.metrics.reorderBuffered.Add(-1, session.metadata.Topic)
+			}
 
 			if dl := s.log.Debug(); dl.Enabled() {
 				dl.Str("session_id", session.sessionID).
@@ -522,8 +557,6 @@ func (s *server) handleCompletion(stream clusterv1.ChunkedSyncService_SyncPartSe
 		session.partCtx.Handler = nil
 	}
 
-	session.completed = true
-
 	partsResults := make([]*clusterv1.PartResult, 0, len(session.partsProgress))
 	allPartsSuccessful := true
 
@@ -547,6 +580,23 @@ func (s *server) handleCompletion(stream clusterv1.ChunkedSyncService_SyncPartSe
 		ChunksReceived:     session.chunksReceived,
 		PartsReceived:      uint32(len(session.partsProgress)),
 		PartsResults:       partsResults,
+	}
+
+	session.releaseMetrics(s.metrics)
+	if s.metrics != nil {
+		topic := session.metadata.Topic
+		s.metrics.chunkedSyncTotalBytes.Inc(float64(syncResult.TotalBytesReceived), topic)
+		s.metrics.chunkedSyncDurationSecs.Observe(float64(syncResult.DurationMs)/1000.0, topic)
+
+		for _, pr := range partsResults {
+			if !pr.Success {
+				reason := failedReasonIncomplete
+				if pr.Error != "" {
+					reason = failedReasonError
+				}
+				s.metrics.chunkedSyncFailedParts.Inc(1, topic, reason)
+			}
+		}
 	}
 
 	if dl := s.log.Debug(); dl.Enabled() {

--- a/banyand/queue/sub/chunked_sync.go
+++ b/banyand/queue/sub/chunked_sync.go
@@ -103,16 +103,17 @@ type chunkBuffer struct {
 }
 
 type syncSession struct {
-	startTime      time.Time
-	metadata       *clusterv1.SyncMetadata
-	partsProgress  map[int]*partProgress
-	partCtx        *queue.ChunkedSyncPartContext
-	chunkBuffer    *chunkBuffer
-	sessionID      string
-	errorMsg       string
-	totalReceived  uint64
-	chunksReceived uint32
-	completed      bool
+	startTime       time.Time
+	metadata        *clusterv1.SyncMetadata
+	partsProgress   map[int]*partProgress
+	partCtx         *queue.ChunkedSyncPartContext
+	chunkBuffer     *chunkBuffer
+	sessionID       string
+	errorMsg        string
+	totalReceived   uint64
+	chunksReceived  uint32
+	abortedRecorded bool
+	completed       bool
 }
 
 type partProgress struct {
@@ -121,7 +122,15 @@ type partProgress struct {
 	completed     bool
 }
 
+const (
+	abortedReasonSwitch      = "switch"
+	abortedReasonStreamError = "stream_error"
+	abortedReasonCtxDone     = "ctx_done"
+	abortedReasonEOF         = "eof"
+)
+
 // releaseMetrics releases the gauges held by this session.
+// Idempotent: safe to call from both handleCompletion and the SyncPart defer.
 func (s *syncSession) releaseMetrics(m *metrics) {
 	if m == nil || s.completed {
 		return
@@ -135,14 +144,30 @@ func (s *syncSession) releaseMetrics(m *metrics) {
 	s.completed = true
 }
 
+func (s *syncSession) recordAborted(m *metrics, reason string) {
+	if m == nil || s.abortedRecorded || s.completed {
+		return
+	}
+	if reason == "" {
+		return
+	}
+	// chunkedSyncAbortedTotal is always initialized in production; tests that wire partial metrics must set it if they trigger abort paths.
+	m.chunkedSyncAbortedTotal.Inc(1, s.metadata.Topic, reason)
+	s.abortedRecorded = true
+}
+
 // SyncPart implements clusterv1.ChunkedSyncServiceServer.
 func (s *server) SyncPart(stream clusterv1.ChunkedSyncService_SyncPartServer) error {
 	ctx := stream.Context()
 	var currentSession *syncSession
 	var sessionID string
+	var abortReason string
 	defer func() {
 		if currentSession == nil {
 			return
+		}
+		if !currentSession.completed {
+			currentSession.recordAborted(s.metrics, abortReason)
 		}
 		currentSession.releaseMetrics(s.metrics)
 		if currentSession.partCtx != nil {
@@ -155,15 +180,18 @@ func (s *server) SyncPart(stream clusterv1.ChunkedSyncService_SyncPartServer) er
 	for {
 		select {
 		case <-ctx.Done():
+			abortReason = abortedReasonCtxDone
 			return ctx.Err()
 		default:
 		}
 
 		req, err := stream.Recv()
 		if errors.Is(err, io.EOF) {
+			abortReason = abortedReasonEOF
 			break
 		}
 		if err != nil {
+			abortReason = abortedReasonStreamError
 			s.log.Error().Err(err).Msg("failed to receive chunk")
 			return err
 		}
@@ -218,6 +246,9 @@ func (s *server) startOrSwitchSession(sessionID string, req *clusterv1.SyncPartR
 }
 
 func (s *server) cleanupPreviousSession(previousSession *syncSession) {
+	if !previousSession.completed {
+		previousSession.recordAborted(s.metrics, abortedReasonSwitch)
+	}
 	previousSession.releaseMetrics(s.metrics)
 
 	if previousSession.partCtx == nil {

--- a/banyand/queue/sub/chunked_sync.go
+++ b/banyand/queue/sub/chunked_sync.go
@@ -590,11 +590,7 @@ func (s *server) handleCompletion(stream clusterv1.ChunkedSyncService_SyncPartSe
 
 		for _, pr := range partsResults {
 			if !pr.Success {
-				reason := failedReasonIncomplete
-				if pr.Error != "" {
-					reason = failedReasonError
-				}
-				s.metrics.chunkedSyncFailedParts.Inc(1, topic, reason)
+				s.metrics.chunkedSyncFailedParts.Inc(1, topic)
 			}
 		}
 	}

--- a/banyand/queue/sub/chunked_sync_test.go
+++ b/banyand/queue/sub/chunked_sync_test.go
@@ -224,6 +224,14 @@ func (c *capturingCounter) uniqueFirstLabelValues() map[string]struct{} {
 	return m
 }
 
+type noopGauge struct{}
+
+func (*noopGauge) Set(_ float64, _ ...string) {}
+
+func (*noopGauge) Add(_ float64, _ ...string) {}
+
+func (*noopGauge) Delete(_ ...string) bool { return true }
+
 func TestChunkOrderingMetricsAreLabeledByTopic_NotSessionID(t *testing.T) {
 	// enable reordering, otherwise the chunk-ordering metrics will not be triggered.
 	s := &server{
@@ -238,15 +246,13 @@ func TestChunkOrderingMetricsAreLabeledByTopic_NotSessionID(t *testing.T) {
 	mockHandler := &MockChunkedSyncHandler{}
 	s.chunkedSyncHandlers[data.TopicStreamPartSync] = mockHandler
 
-	// metrics: this test will trigger at least two events:
-	// - out_of_order_received
-	// - chunk_buffered
-	// so must put both counters, otherwise nil.Inc will panic.
 	outOfOrder := &capturingCounter{}
 	buffered := &capturingCounter{}
+	reorderBuffered := &noopGauge{}
 	s.metrics = &metrics{
 		outOfOrderChunksReceived: outOfOrder,
 		chunksBuffered:           buffered,
+		reorderBuffered:          reorderBuffered,
 		// other counters will not be triggered in this test, leave them nil
 	}
 

--- a/banyand/queue/sub/chunked_sync_test.go
+++ b/banyand/queue/sub/chunked_sync_test.go
@@ -224,14 +224,6 @@ func (c *capturingCounter) uniqueFirstLabelValues() map[string]struct{} {
 	return m
 }
 
-type noopGauge struct{}
-
-func (*noopGauge) Set(_ float64, _ ...string) {}
-
-func (*noopGauge) Add(_ float64, _ ...string) {}
-
-func (*noopGauge) Delete(_ ...string) bool { return true }
-
 func TestChunkOrderingMetricsAreLabeledByTopic_NotSessionID(t *testing.T) {
 	// enable reordering, otherwise the chunk-ordering metrics will not be triggered.
 	s := &server{
@@ -248,13 +240,10 @@ func TestChunkOrderingMetricsAreLabeledByTopic_NotSessionID(t *testing.T) {
 
 	outOfOrder := &capturingCounter{}
 	buffered := &capturingCounter{}
-	reorderBuffered := &noopGauge{}
-	s.metrics = &metrics{
-		outOfOrderChunksReceived: outOfOrder,
-		chunksBuffered:           buffered,
-		reorderBuffered:          reorderBuffered,
-		// other counters will not be triggered in this test, leave them nil
-	}
+	testMetrics := newTestMetrics()
+	testMetrics.outOfOrderChunksReceived = outOfOrder
+	testMetrics.chunksBuffered = buffered
+	s.metrics = testMetrics
 
 	topic := data.TopicStreamPartSync.String()
 

--- a/banyand/queue/sub/server.go
+++ b/banyand/queue/sub/server.go
@@ -427,6 +427,7 @@ type metrics struct {
 	reorderBuffered    meter.Gauge
 
 	// Chunked sync outcome metrics
+	chunkedSyncAbortedTotal meter.Counter
 	chunkedSyncFailedParts  meter.Counter
 	chunkedSyncTotalBytes   meter.Counter
 	chunkedSyncDurationSecs meter.Histogram
@@ -456,6 +457,7 @@ func newMetrics(factory observability.Factory) *metrics {
 		reorderBuffered:    factory.NewGauge("chunk_reorder_buffered_chunks", "topic"),
 
 		// Chunked sync outcome metrics
+		chunkedSyncAbortedTotal: factory.NewCounter("chunked_sync_aborted_total", "topic", "reason"),
 		chunkedSyncFailedParts:  factory.NewCounter("chunked_sync_failed_parts_total", "topic"),
 		chunkedSyncTotalBytes:   factory.NewCounter("chunked_sync_total_bytes_received", "topic"),
 		chunkedSyncDurationSecs: factory.NewHistogram("chunked_sync_duration_seconds", meter.DefBuckets, "topic"),

--- a/banyand/queue/sub/server.go
+++ b/banyand/queue/sub/server.go
@@ -59,12 +59,7 @@ import (
 	pkgtls "github.com/apache/skywalking-banyandb/pkg/tls"
 )
 
-const (
-	defaultRecvSize = 10 << 20
-
-	failedReasonIncomplete = "incomplete"
-	failedReasonError      = "error"
-)
+const defaultRecvSize = 10 << 20
 
 var (
 	errServerCert = errors.New("invalid server cert file")
@@ -461,7 +456,7 @@ func newMetrics(factory observability.Factory) *metrics {
 		reorderBuffered:    factory.NewGauge("chunk_reorder_buffered_chunks", "topic"),
 
 		// Chunked sync outcome metrics
-		chunkedSyncFailedParts:  factory.NewCounter("chunked_sync_failed_parts_total", "topic", "reason"),
+		chunkedSyncFailedParts:  factory.NewCounter("chunked_sync_failed_parts_total", "topic"),
 		chunkedSyncTotalBytes:   factory.NewCounter("chunked_sync_total_bytes_received", "topic"),
 		chunkedSyncDurationSecs: factory.NewHistogram("chunked_sync_duration_seconds", meter.DefBuckets, "topic"),
 	}

--- a/banyand/queue/sub/server.go
+++ b/banyand/queue/sub/server.go
@@ -59,7 +59,12 @@ import (
 	pkgtls "github.com/apache/skywalking-banyandb/pkg/tls"
 )
 
-const defaultRecvSize = 10 << 20
+const (
+	defaultRecvSize = 10 << 20
+
+	failedReasonIncomplete = "incomplete"
+	failedReasonError      = "error"
+)
 
 var (
 	errServerCert = errors.New("invalid server cert file")
@@ -421,6 +426,15 @@ type metrics struct {
 	largeGapsRejected        meter.Counter
 	bufferCapacityExceeded   meter.Counter
 	finishSyncErr            meter.Counter
+
+	// Chunked sync saturation metrics
+	activeSyncSessions meter.Gauge
+	reorderBuffered    meter.Gauge
+
+	// Chunked sync outcome metrics
+	chunkedSyncFailedParts  meter.Counter
+	chunkedSyncTotalBytes   meter.Counter
+	chunkedSyncDurationSecs meter.Histogram
 }
 
 func newMetrics(factory observability.Factory) *metrics {
@@ -441,6 +455,15 @@ func newMetrics(factory observability.Factory) *metrics {
 		largeGapsRejected:        factory.NewCounter("large_gaps_rejected", "topic"),
 		bufferCapacityExceeded:   factory.NewCounter("buffer_capacity_exceeded", "topic"),
 		finishSyncErr:            factory.NewCounter("finish_sync_err", "topic"),
+
+		// Chunked sync saturation metrics
+		activeSyncSessions: factory.NewGauge("chunked_sync_active_sessions", "topic"),
+		reorderBuffered:    factory.NewGauge("chunk_reorder_buffered_chunks", "topic"),
+
+		// Chunked sync outcome metrics
+		chunkedSyncFailedParts:  factory.NewCounter("chunked_sync_failed_parts_total", "topic", "reason"),
+		chunkedSyncTotalBytes:   factory.NewCounter("chunked_sync_total_bytes_received", "topic"),
+		chunkedSyncDurationSecs: factory.NewHistogram("chunked_sync_duration_seconds", meter.DefBuckets, "topic"),
 	}
 }
 

--- a/banyand/queue/sub/server.go
+++ b/banyand/queue/sub/server.go
@@ -48,6 +48,7 @@ import (
 	tracev1 "github.com/apache/skywalking-banyandb/api/proto/banyandb/trace/v1"
 	"github.com/apache/skywalking-banyandb/banyand/liaison/grpc/route"
 	"github.com/apache/skywalking-banyandb/banyand/metadata"
+	"github.com/apache/skywalking-banyandb/banyand/metadata/schema/property"
 	"github.com/apache/skywalking-banyandb/banyand/observability"
 	"github.com/apache/skywalking-banyandb/banyand/queue"
 	"github.com/apache/skywalking-banyandb/pkg/bus"
@@ -291,6 +292,24 @@ func (s *server) Serve() run.StopNotify {
 	tracev1.RegisterTraceServiceServer(s.ser, &traceService{ser: s})
 	if s.metadataRepo != nil {
 		fodcv1.RegisterGroupLifecycleServiceServer(s.ser, s)
+		// Phase 2 Step 2.1: data nodes expose NodeSchemaStatusService so the
+		// liaison's barrier fan-out (Step 2.2) can probe each node's local
+		// schema cache. The cache the server reads is the same SchemaRegistry
+		// instance the data-node query executor consults — see
+		// banyand/metadata/schema/property/node_status.go for the coherence
+		// argument. The registry is resolved per request (closure) so the
+		// service registers even when SchemaRegistry isn't ready at Serve
+		// time; the fail-closed nil-cache contract handles in-flight probes
+		// during initialization.
+		if svc, svcOk := s.metadataRepo.(metadata.Service); svcOk {
+			clusterv1.RegisterNodeSchemaStatusServiceServer(s.ser, property.NewNodeSchemaStatusServerForRegistry(func() *property.SchemaRegistry {
+				reg, regOk := svc.SchemaRegistry().(*property.SchemaRegistry)
+				if !regOk {
+					return nil
+				}
+				return reg
+			}))
+		}
 	}
 
 	var ctx context.Context

--- a/banyand/queue/sub/server_metrics_test.go
+++ b/banyand/queue/sub/server_metrics_test.go
@@ -126,11 +126,7 @@ func TestCompletionOutcomeMetricsRecorded(t *testing.T) {
 	s.metrics.chunkedSyncDurationSecs.Observe(float64(syncResult.DurationMs)/1000.0, topic)
 	for _, pr := range partsResults {
 		if !pr.Success {
-			reason := failedReasonIncomplete
-			if pr.Error != "" {
-				reason = failedReasonError
-			}
-			s.metrics.chunkedSyncFailedParts.Inc(1, topic, reason)
+			s.metrics.chunkedSyncFailedParts.Inc(1, topic)
 		}
 	}
 

--- a/banyand/queue/sub/server_metrics_test.go
+++ b/banyand/queue/sub/server_metrics_test.go
@@ -24,8 +24,58 @@ import (
 	"github.com/stretchr/testify/require"
 
 	clusterv1 "github.com/apache/skywalking-banyandb/api/proto/banyandb/cluster/v1"
+	"github.com/apache/skywalking-banyandb/banyand/queue"
+	"github.com/apache/skywalking-banyandb/pkg/logger"
 	"github.com/apache/skywalking-banyandb/pkg/meter"
 )
+
+type noopCounter struct{}
+
+func (*noopCounter) Inc(_ float64, _ ...string) {}
+func (*noopCounter) Delete(_ ...string) bool    { return true }
+
+type noopGauge struct{}
+
+func (*noopGauge) Set(_ float64, _ ...string) {}
+func (*noopGauge) Add(_ float64, _ ...string) {}
+func (*noopGauge) Delete(_ ...string) bool    { return true }
+
+type noopHistogram struct{}
+
+func (*noopHistogram) Observe(_ float64, _ ...string) {}
+func (*noopHistogram) Delete(_ ...string) bool        { return true }
+
+func newTestMetrics() *metrics {
+	c := &noopCounter{}
+	g := &noopGauge{}
+	h := &noopHistogram{}
+	return &metrics{
+		totalStarted:  c,
+		totalFinished: c,
+		totalErr:      c,
+		totalLatency:  c,
+
+		totalMsgReceived:    c,
+		totalMsgReceivedErr: c,
+		totalMsgSent:        c,
+		totalMsgSentErr:     c,
+
+		outOfOrderChunksReceived: c,
+		chunksBuffered:           c,
+		bufferTimeouts:           c,
+		largeGapsRejected:        c,
+		bufferCapacityExceeded:   c,
+		finishSyncErr:            c,
+
+		activeSyncSessions: g,
+		reorderBuffered:    g,
+
+		chunkedSyncAbortedTotal: c,
+		chunkedSyncFailedParts:  c,
+		chunkedSyncTotalBytes:   c,
+		chunkedSyncDurationSecs: h,
+	}
+}
 
 type fakeCounter struct {
 	total float64
@@ -84,10 +134,21 @@ func TestReleaseMetricsReleasesGauges(t *testing.T) {
 }
 
 func TestCompletionOutcomeMetricsRecorded(t *testing.T) {
+	logInitErr := logger.Init(logger.Logging{
+		Env:   "dev",
+		Level: "info",
+	})
+	require.NoError(t, logInitErr)
+
+	topic := "v1:stream-part-sync"
+	totalBytes := float64(10)
+
 	s := &server{
+		log: logger.GetLogger("test-server-completion-metrics"),
 		metrics: &metrics{
 			activeSyncSessions:      newFakeGauge(),
 			reorderBuffered:         newFakeGauge(),
+			chunkedSyncAbortedTotal: &fakeCounter{},
 			chunkedSyncFailedParts:  &fakeCounter{},
 			chunkedSyncTotalBytes:   &fakeCounter{},
 			chunkedSyncDurationSecs: &fakeHistogram{},
@@ -97,7 +158,8 @@ func TestCompletionOutcomeMetricsRecorded(t *testing.T) {
 	session := &syncSession{
 		sessionID: "s1",
 		startTime: time.Now().Add(-2 * time.Second),
-		metadata:  &clusterv1.SyncMetadata{Topic: "v1:stream-part-sync"},
+		metadata:  &clusterv1.SyncMetadata{Topic: topic},
+		partCtx:   &queue.ChunkedSyncPartContext{},
 		partsProgress: map[int]*partProgress{
 			0: {totalBytes: 10, receivedBytes: 10, completed: true},
 			1: {totalBytes: 10, receivedBytes: 0, completed: false},
@@ -106,29 +168,54 @@ func TestCompletionOutcomeMetricsRecorded(t *testing.T) {
 		chunksReceived: 2,
 	}
 
-	// Directly simulate the tail of handleCompletion logic:
-	partsResults := []*clusterv1.PartResult{
-		{Success: true, Error: "", BytesProcessed: 10},
-		{Success: false, Error: "some error", BytesProcessed: 0},
-	}
-	syncResult := &clusterv1.SyncResult{
-		Success:            false,
-		TotalBytesReceived: session.totalReceived,
-		DurationMs:         time.Since(session.startTime).Milliseconds(),
-		ChunksReceived:     session.chunksReceived,
-		PartsReceived:      uint32(len(session.partsProgress)),
-		PartsResults:       partsResults,
-	}
+	// Simulate start increments that would have happened on session creation.
+	s.metrics.activeSyncSessions.Add(1, topic)
 
-	session.releaseMetrics(s.metrics)
-	topic := session.metadata.Topic
-	s.metrics.chunkedSyncTotalBytes.Inc(float64(syncResult.TotalBytesReceived), topic)
-	s.metrics.chunkedSyncDurationSecs.Observe(float64(syncResult.DurationMs)/1000.0, topic)
-	for _, pr := range partsResults {
-		if !pr.Success {
-			s.metrics.chunkedSyncFailedParts.Inc(1, topic)
-		}
+	mockStream := &MockSyncPartStream{}
+	req := &clusterv1.SyncPartRequest{
+		SessionId:  session.sessionID,
+		ChunkIndex: 0,
+		Content: &clusterv1.SyncPartRequest_Completion{
+			Completion: &clusterv1.SyncCompletion{},
+		},
 	}
+	handleErr := s.handleCompletion(mockStream, session, req)
+	require.NoError(t, handleErr)
 
+	require.Equal(t, totalBytes, s.metrics.chunkedSyncTotalBytes.(*fakeCounter).total)
+	require.Equal(t, 1, s.metrics.chunkedSyncDurationSecs.(*fakeHistogram).count)
+	require.Equal(t, float64(1), s.metrics.chunkedSyncFailedParts.(*fakeCounter).total)
+	require.Equal(t, float64(0), getGaugeValue(s.metrics.activeSyncSessions))
 	require.True(t, session.completed)
+}
+
+func TestCleanupPreviousSessionRecordsAborted(t *testing.T) {
+	logInitErr := logger.Init(logger.Logging{
+		Env:   "dev",
+		Level: "info",
+	})
+	require.NoError(t, logInitErr)
+
+	topic := "v1:stream-part-sync"
+	s := &server{
+		log: logger.GetLogger("test-server-switch-abort"),
+		metrics: &metrics{
+			activeSyncSessions:      newFakeGauge(),
+			reorderBuffered:         newFakeGauge(),
+			chunkedSyncAbortedTotal: &fakeCounter{},
+		},
+	}
+
+	prev := &syncSession{
+		sessionID: "s1",
+		startTime: time.Now().Add(-time.Second),
+		metadata:  &clusterv1.SyncMetadata{Topic: topic},
+	}
+	s.metrics.activeSyncSessions.Add(1, topic)
+
+	s.cleanupPreviousSession(prev)
+
+	require.True(t, prev.abortedRecorded)
+	require.Equal(t, float64(1), s.metrics.chunkedSyncAbortedTotal.(*fakeCounter).total)
+	require.Equal(t, float64(0), getGaugeValue(s.metrics.activeSyncSessions))
 }

--- a/banyand/queue/sub/server_metrics_test.go
+++ b/banyand/queue/sub/server_metrics_test.go
@@ -1,0 +1,138 @@
+// Licensed to Apache Software Foundation (ASF) under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Apache Software Foundation (ASF) licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package sub
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	clusterv1 "github.com/apache/skywalking-banyandb/api/proto/banyandb/cluster/v1"
+	"github.com/apache/skywalking-banyandb/pkg/meter"
+)
+
+type fakeCounter struct {
+	total float64
+}
+
+func (f *fakeCounter) Inc(delta float64, _ ...string) { f.total += delta }
+func (*fakeCounter) Delete(_ ...string) bool          { return true }
+
+type fakeGauge struct {
+	value float64
+}
+
+func (g *fakeGauge) Set(v float64, _ ...string)     { g.value = v }
+func (g *fakeGauge) Add(delta float64, _ ...string) { g.value += delta }
+func (*fakeGauge) Delete(_ ...string) bool          { return true }
+func newFakeGauge() meter.Gauge                     { return &fakeGauge{} }
+func getGaugeValue(g meter.Gauge) float64           { return g.(*fakeGauge).value }
+
+type fakeHistogram struct {
+	count int
+}
+
+func (h *fakeHistogram) Observe(_ float64, _ ...string) { h.count++ }
+func (*fakeHistogram) Delete(_ ...string) bool          { return true }
+
+func TestReleaseMetricsReleasesGauges(t *testing.T) {
+	m := &metrics{
+		activeSyncSessions: newFakeGauge(),
+		reorderBuffered:    newFakeGauge(),
+	}
+
+	sess := &syncSession{
+		sessionID: "s1",
+		startTime: time.Now(),
+		metadata:  &clusterv1.SyncMetadata{Topic: "v1:stream-part-sync"},
+		chunkBuffer: &chunkBuffer{
+			chunks: map[uint32]*clusterv1.SyncPartRequest{
+				2: {ChunkIndex: 2},
+				3: {ChunkIndex: 3},
+			},
+		},
+	}
+
+	// simulate start increments
+	m.activeSyncSessions.Add(1, sess.metadata.Topic)
+	m.reorderBuffered.Add(2, sess.metadata.Topic)
+
+	sess.releaseMetrics(m)
+
+	require.Equal(t, float64(0), getGaugeValue(m.activeSyncSessions))
+	require.Equal(t, float64(0), getGaugeValue(m.reorderBuffered))
+	// idempotent
+	sess.releaseMetrics(m)
+	require.Equal(t, float64(0), getGaugeValue(m.activeSyncSessions))
+	require.Equal(t, float64(0), getGaugeValue(m.reorderBuffered))
+}
+
+func TestCompletionOutcomeMetricsRecorded(t *testing.T) {
+	s := &server{
+		metrics: &metrics{
+			activeSyncSessions:      newFakeGauge(),
+			reorderBuffered:         newFakeGauge(),
+			chunkedSyncFailedParts:  &fakeCounter{},
+			chunkedSyncTotalBytes:   &fakeCounter{},
+			chunkedSyncDurationSecs: &fakeHistogram{},
+		},
+	}
+
+	session := &syncSession{
+		sessionID: "s1",
+		startTime: time.Now().Add(-2 * time.Second),
+		metadata:  &clusterv1.SyncMetadata{Topic: "v1:stream-part-sync"},
+		partsProgress: map[int]*partProgress{
+			0: {totalBytes: 10, receivedBytes: 10, completed: true},
+			1: {totalBytes: 10, receivedBytes: 0, completed: false},
+		},
+		totalReceived:  10,
+		chunksReceived: 2,
+	}
+
+	// Directly simulate the tail of handleCompletion logic:
+	partsResults := []*clusterv1.PartResult{
+		{Success: true, Error: "", BytesProcessed: 10},
+		{Success: false, Error: "some error", BytesProcessed: 0},
+	}
+	syncResult := &clusterv1.SyncResult{
+		Success:            false,
+		TotalBytesReceived: session.totalReceived,
+		DurationMs:         time.Since(session.startTime).Milliseconds(),
+		ChunksReceived:     session.chunksReceived,
+		PartsReceived:      uint32(len(session.partsProgress)),
+		PartsResults:       partsResults,
+	}
+
+	session.releaseMetrics(s.metrics)
+	topic := session.metadata.Topic
+	s.metrics.chunkedSyncTotalBytes.Inc(float64(syncResult.TotalBytesReceived), topic)
+	s.metrics.chunkedSyncDurationSecs.Observe(float64(syncResult.DurationMs)/1000.0, topic)
+	for _, pr := range partsResults {
+		if !pr.Success {
+			reason := failedReasonIncomplete
+			if pr.Error != "" {
+				reason = failedReasonError
+			}
+			s.metrics.chunkedSyncFailedParts.Inc(1, topic, reason)
+		}
+	}
+
+	require.True(t, session.completed)
+}

--- a/fodc/agent/internal/lifecycle/collector.go
+++ b/fodc/agent/internal/lifecycle/collector.go
@@ -20,6 +20,7 @@ package lifecycle
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 	"sort"
@@ -34,6 +35,7 @@ import (
 	"google.golang.org/grpc/status"
 
 	fodcv1 "github.com/apache/skywalking-banyandb/api/proto/banyandb/fodc/v1"
+	"github.com/apache/skywalking-banyandb/fodc/internal/timeouts"
 	"github.com/apache/skywalking-banyandb/pkg/logger"
 )
 
@@ -43,8 +45,6 @@ const (
 	maxReportFiles    = 5
 	maxReportFileSize = 5 * 1024 * 1024 // 5MB
 )
-
-const grpcTimeout = 10 * time.Second
 
 // Collector collects lifecycle data from local files.
 type Collector struct {
@@ -73,8 +73,10 @@ func NewCollector(log *logger.Logger, grpcAddr, reportDir string, cacheTTL time.
 	}
 }
 
-// Collect collects lifecycle data from local files.
-// Data is cached for cacheTTL duration; after expiry the next call refreshes the cache.
+// Collect returns lifecycle data, serving the cache when fresh. A transient InspectAll
+// failure is propagated to the caller (the cache is left untouched so the next call
+// retries) so that callers can distinguish a real failure from a healthy liaison that
+// happens to have zero groups.
 func (c *Collector) Collect(ctx context.Context) (*fodcv1.LifecycleData, error) {
 	c.mu.RLock()
 	if c.currentData != nil && c.cacheTTL > 0 && c.nowFunc().Sub(c.lastCollectTime) < c.cacheTTL {
@@ -84,9 +86,19 @@ func (c *Collector) Collect(ctx context.Context) (*fodcv1.LifecycleData, error) 
 	}
 	c.mu.RUnlock()
 
+	reports := c.readReportFiles()
+	groups, err := c.collectGroups(ctx)
+	if err != nil {
+		if c.log != nil {
+			c.log.Warn().Err(err).Int("reports", len(reports)).
+				Msg("InspectAll failed; cache untouched, propagating error to caller")
+		}
+		return nil, err
+	}
+
 	data := &fodcv1.LifecycleData{
-		Reports: c.readReportFiles(),
-		Groups:  c.collectGroups(ctx),
+		Reports: reports,
+		Groups:  groups,
 	}
 	c.mu.Lock()
 	c.currentData = data
@@ -95,23 +107,28 @@ func (c *Collector) Collect(ctx context.Context) (*fodcv1.LifecycleData, error) 
 	return data, nil
 }
 
-func (c *Collector) collectGroups(ctx context.Context) []*fodcv1.GroupLifecycleInfo {
+// collectGroups invokes InspectAll on the local liaison.
+//
+// Return contract:
+//   - (nil, nil): no RPC was issued (grpcAddr empty, or InspectAll already known to be Unimplemented).
+//     Callers treat this as a successful collection with no groups.
+//   - (non-nil slice, nil): RPC succeeded. The slice is empty (non-nil) when the server returned no groups.
+//   - (nil, err): a transient error occurred (DeadlineExceeded, Unavailable, dial failure, etc.).
+//     Callers must NOT cache this outcome.
+func (c *Collector) collectGroups(ctx context.Context) ([]*fodcv1.GroupLifecycleInfo, error) {
 	if c.grpcAddr == "" || c.grpcUnimplemented.Load() {
-		return nil
+		return nil, nil
 	}
 	conn, err := grpc.NewClient(c.grpcAddr, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
-		if c.log != nil {
-			c.log.Warn().Err(err).Str("addr", c.grpcAddr).Msg("Failed to create gRPC connection for InspectAll")
-		}
-		return nil
+		return nil, fmt.Errorf("dial %s: %w", c.grpcAddr, err)
 	}
 	defer func() {
 		_ = conn.Close()
 	}()
 
 	client := fodcv1.NewGroupLifecycleServiceClient(conn)
-	reqCtx, cancel := context.WithTimeout(ctx, grpcTimeout)
+	reqCtx, cancel := context.WithTimeout(ctx, timeouts.AgentInspectAll)
 	defer cancel()
 	resp, err := client.InspectAll(reqCtx, &fodcv1.InspectAllRequest{})
 	if err != nil {
@@ -120,14 +137,15 @@ func (c *Collector) collectGroups(ctx context.Context) []*fodcv1.GroupLifecycleI
 			if c.log != nil {
 				c.log.Info().Str("addr", c.grpcAddr).Msg("GroupLifecycleService.InspectAll is not implemented, skipping future calls")
 			}
-			return nil
+			return nil, nil
 		}
-		if c.log != nil {
-			c.log.Warn().Err(err).Str("addr", c.grpcAddr).Msg("InspectAll failed, skipping groups")
-		}
-		return nil
+		return nil, fmt.Errorf("InspectAll on %s: %w", c.grpcAddr, err)
 	}
-	return resp.GetGroups()
+	got := resp.GetGroups()
+	if got == nil {
+		return []*fodcv1.GroupLifecycleInfo{}, nil
+	}
+	return got, nil
 }
 
 func (c *Collector) readReportFiles() []*fodcv1.LifecycleReport {

--- a/fodc/agent/internal/lifecycle/collector_test.go
+++ b/fodc/agent/internal/lifecycle/collector_test.go
@@ -18,14 +18,21 @@
 package lifecycle
 
 import (
+	"context"
+	"net"
 	"os"
 	"path/filepath"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
+	fodcv1 "github.com/apache/skywalking-banyandb/api/proto/banyandb/fodc/v1"
 	"github.com/apache/skywalking-banyandb/pkg/logger"
 )
 
@@ -34,6 +41,73 @@ func initTestLogger(t *testing.T) *logger.Logger {
 	err := logger.Init(logger.Logging{Env: "dev", Level: "debug"})
 	require.NoError(t, err)
 	return logger.GetLogger("test", "lifecycle")
+}
+
+// fakeLifecycleService is a programmable test double for GroupLifecycleService.InspectAll.
+// Each registered behavior is consumed in order; the call counter lets tests assert how
+// many times Collect actually reached the gRPC server (i.e. whether the cache served the
+// request without an RPC).
+type fakeLifecycleService struct {
+	fodcv1.UnimplementedGroupLifecycleServiceServer
+	behaviors []func() (*fodcv1.InspectAllResponse, error)
+	mu        sync.Mutex
+	callCount int
+}
+
+func (f *fakeLifecycleService) InspectAll(_ context.Context, _ *fodcv1.InspectAllRequest) (*fodcv1.InspectAllResponse, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.callCount >= len(f.behaviors) {
+		f.callCount++
+		return nil, status.Error(codes.Internal, "fakeLifecycleService: behavior list exhausted")
+	}
+	behavior := f.behaviors[f.callCount]
+	f.callCount++
+	return behavior()
+}
+
+func (f *fakeLifecycleService) calls() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.callCount
+}
+
+func returnGroups(groups []*fodcv1.GroupLifecycleInfo) func() (*fodcv1.InspectAllResponse, error) {
+	return func() (*fodcv1.InspectAllResponse, error) {
+		return &fodcv1.InspectAllResponse{Groups: groups}, nil
+	}
+}
+
+func returnError(code codes.Code, msg string) func() (*fodcv1.InspectAllResponse, error) {
+	return func() (*fodcv1.InspectAllResponse, error) {
+		return nil, status.Error(code, msg)
+	}
+}
+
+// startLocalServer spins up a real gRPC server on a random localhost port hosting the
+// supplied fake and returns the listen address. The server is torn down via t.Cleanup.
+func startLocalServer(t *testing.T, fake *fakeLifecycleService) string {
+	t.Helper()
+	lis, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	srv := grpc.NewServer()
+	fodcv1.RegisterGroupLifecycleServiceServer(srv, fake)
+	go func() {
+		_ = srv.Serve(lis)
+	}()
+	t.Cleanup(srv.Stop)
+	return lis.Addr().String()
+}
+
+// newCollectorForFake constructs a Collector wired to a fresh local gRPC server backed by fake.
+func newCollectorForFake(t *testing.T, fake *fakeLifecycleService, cacheTTL time.Duration) *Collector {
+	t.Helper()
+	addr := startLocalServer(t, fake)
+	return NewCollector(initTestLogger(t), addr, t.TempDir(), cacheTTL)
+}
+
+func sampleGroup(name string) *fodcv1.GroupLifecycleInfo {
+	return &fodcv1.GroupLifecycleInfo{Name: name}
 }
 
 func TestNewCollector(t *testing.T) {
@@ -51,11 +125,10 @@ func TestCollector_ReadReportFiles_EmptyDir(t *testing.T) {
 	assert.Empty(t, reports)
 }
 
-func TestCollector_Collect(t *testing.T) {
+func TestCollector_Collect_NoGRPC(t *testing.T) {
 	log := initTestLogger(t)
 	collector := NewCollector(log, "", "", 0)
-	ctx := t.Context()
-	data, err := collector.Collect(ctx)
+	data, err := collector.Collect(t.Context())
 	require.NoError(t, err)
 	require.NotNil(t, data)
 	assert.NotNil(t, collector.currentData)
@@ -88,20 +161,19 @@ func TestCollector_CacheTTL(t *testing.T) {
 	assert.NotSame(t, data1, data3)
 }
 
-func TestCollector_GrpcUnimplemented_SkipsFutureCalls(t *testing.T) {
+func TestCollector_ZeroTTL_AlwaysRefreshes(t *testing.T) {
 	log := initTestLogger(t)
-	collector := NewCollector(log, "localhost:0", "", 0)
+	collector := NewCollector(log, "", "", 0)
+	ctx := t.Context()
 
-	assert.False(t, collector.grpcUnimplemented.Load())
+	data1, err := collector.Collect(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, data1)
 
-	groups := collector.collectGroups(t.Context())
-	assert.Nil(t, groups)
-	assert.False(t, collector.grpcUnimplemented.Load())
-
-	collector.grpcUnimplemented.Store(true)
-	groups = collector.collectGroups(t.Context())
-	assert.Nil(t, groups)
-	assert.True(t, collector.grpcUnimplemented.Load())
+	data2, err := collector.Collect(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, data2)
+	assert.NotSame(t, data1, data2)
 }
 
 func TestCollector_ReadReportFiles_MaxFiles(t *testing.T) {
@@ -109,7 +181,6 @@ func TestCollector_ReadReportFiles_MaxFiles(t *testing.T) {
 	dir := t.TempDir()
 	collector := NewCollector(log, "", dir, 0)
 
-	// Create 7 files with timestamp-like names so sort order is predictable
 	for idx, name := range []string{
 		"2026-03-20.json",
 		"2026-03-21.json",
@@ -165,18 +236,172 @@ func TestCollector_ReadReportFiles_OversizedFile(t *testing.T) {
 	assert.Equal(t, "2026-03-26.json", reports[0].Filename)
 }
 
-func TestCollector_ZeroTTL_AlwaysRefreshes(t *testing.T) {
+func TestCollectGroups_NoGRPCAddrShortCircuits(t *testing.T) {
 	log := initTestLogger(t)
 	collector := NewCollector(log, "", "", 0)
+	groups, err := collector.collectGroups(t.Context())
+	require.NoError(t, err)
+	assert.Nil(t, groups)
+}
+
+func TestCollectGroups_UnimplementedSetsFlagAndCachesNil(t *testing.T) {
+	fake := &fakeLifecycleService{
+		behaviors: []func() (*fodcv1.InspectAllResponse, error){
+			returnError(codes.Unimplemented, "not supported"),
+		},
+	}
+	collector := newCollectorForFake(t, fake, time.Minute)
+
+	groups, err := collector.collectGroups(t.Context())
+	require.NoError(t, err)
+	assert.Nil(t, groups)
+	assert.True(t, collector.grpcUnimplemented.Load())
+
+	// Subsequent direct calls short-circuit without touching the server.
+	groups2, err := collector.collectGroups(t.Context())
+	require.NoError(t, err)
+	assert.Nil(t, groups2)
+	assert.Equal(t, 1, fake.calls())
+}
+
+func TestCollectGroups_NilResponseGroupsBecomesEmptySlice(t *testing.T) {
+	fake := &fakeLifecycleService{
+		behaviors: []func() (*fodcv1.InspectAllResponse, error){
+			returnGroups(nil),
+		},
+	}
+	collector := newCollectorForFake(t, fake, time.Minute)
+
+	groups, err := collector.collectGroups(t.Context())
+	require.NoError(t, err)
+	require.NotNil(t, groups, "successful InspectAll with empty groups must return non-nil empty slice, not nil")
+	assert.Empty(t, groups)
+}
+
+func TestCollect_CachesSuccessfulResult(t *testing.T) {
+	fake := &fakeLifecycleService{
+		behaviors: []func() (*fodcv1.InspectAllResponse, error){
+			returnGroups([]*fodcv1.GroupLifecycleInfo{sampleGroup("g1"), sampleGroup("g2")}),
+		},
+	}
+	collector := newCollectorForFake(t, fake, time.Minute)
 	ctx := t.Context()
 
 	data1, err := collector.Collect(ctx)
 	require.NoError(t, err)
-	require.NotNil(t, data1)
+	require.Len(t, data1.Groups, 2)
 
 	// With zero TTL, every call should re-collect
 	data2, err := collector.Collect(ctx)
 	require.NoError(t, err)
-	require.NotNil(t, data2)
-	assert.NotSame(t, data1, data2)
+	assert.Same(t, data1, data2, "second Collect within TTL must return the cached pointer")
+	assert.Equal(t, 1, fake.calls(), "InspectAll must not be invoked on cache hit")
+}
+
+func TestCollect_DoesNotCacheTransientFailure(t *testing.T) {
+	fake := &fakeLifecycleService{
+		behaviors: []func() (*fodcv1.InspectAllResponse, error){
+			returnError(codes.DeadlineExceeded, "simulated timeout"),
+			returnGroups([]*fodcv1.GroupLifecycleInfo{sampleGroup("g1")}),
+		},
+	}
+	collector := newCollectorForFake(t, fake, 10*time.Minute)
+	ctx := t.Context()
+
+	data1, err := collector.Collect(ctx)
+	require.Error(t, err, "transient failure must propagate to caller")
+	assert.Nil(t, data1, "no LifecycleData on failure")
+
+	collector.mu.RLock()
+	cachedData := collector.currentData
+	cachedTime := collector.lastCollectTime
+	collector.mu.RUnlock()
+	assert.Nil(t, cachedData, "transient failure must not write to cache")
+	assert.True(t, cachedTime.IsZero(), "lastCollectTime must remain zero after transient failure")
+
+	data2, err := collector.Collect(ctx)
+	require.NoError(t, err)
+	require.Len(t, data2.Groups, 1, "next call must retry InspectAll, not return stale empty")
+	assert.Equal(t, "g1", data2.Groups[0].Name)
+	assert.Equal(t, 2, fake.calls(), "InspectAll must be invoked twice")
+}
+
+func TestCollect_FailurePropagatesError(t *testing.T) {
+	successGroups := []*fodcv1.GroupLifecycleInfo{sampleGroup("g1"), sampleGroup("g2"), sampleGroup("g3")}
+	fake := &fakeLifecycleService{
+		behaviors: []func() (*fodcv1.InspectAllResponse, error){
+			returnGroups(successGroups),
+			returnError(codes.DeadlineExceeded, "simulated timeout"),
+		},
+	}
+	collector := newCollectorForFake(t, fake, 0) // zero TTL forces both calls to hit the server
+	ctx := t.Context()
+
+	data1, err := collector.Collect(ctx)
+	require.NoError(t, err)
+	require.Len(t, data1.Groups, 3)
+
+	data2, err := collector.Collect(ctx)
+	require.Error(t, err, "transient failure after a successful collect must still surface as an error")
+	assert.Nil(t, data2, "caller must not receive a LifecycleData payload on failure")
+	assert.Equal(t, 2, fake.calls())
+}
+
+func TestCollect_TransientFailureDoesNotAdvanceLastCollectTime(t *testing.T) {
+	fake := &fakeLifecycleService{
+		behaviors: []func() (*fodcv1.InspectAllResponse, error){
+			returnGroups([]*fodcv1.GroupLifecycleInfo{sampleGroup("g1")}),
+			returnError(codes.Unavailable, "simulated outage"),
+			returnGroups([]*fodcv1.GroupLifecycleInfo{sampleGroup("g1"), sampleGroup("g2")}),
+		},
+	}
+	collector := newCollectorForFake(t, fake, time.Hour)
+	ctx := t.Context()
+
+	now := time.Unix(1_000_000_000, 0)
+	collector.nowFunc = func() time.Time { return now }
+
+	_, err := collector.Collect(ctx)
+	require.NoError(t, err)
+	collector.mu.RLock()
+	successTime := collector.lastCollectTime
+	collector.mu.RUnlock()
+	assert.Equal(t, now, successTime)
+
+	now = now.Add(2 * time.Hour) // expire the cache to force a new RPC
+	_, err = collector.Collect(ctx)
+	require.Error(t, err, "transient failure must surface as an error to the caller")
+	collector.mu.RLock()
+	failureTime := collector.lastCollectTime
+	collector.mu.RUnlock()
+	assert.Equal(t, successTime, failureTime, "transient failure must not advance lastCollectTime")
+
+	data, err := collector.Collect(ctx)
+	require.NoError(t, err)
+	require.Len(t, data.Groups, 2, "after recovery, fresh groups must be cached")
+	assert.Equal(t, 3, fake.calls())
+}
+
+func TestCollect_UnimplementedCachesAndStops(t *testing.T) {
+	fake := &fakeLifecycleService{
+		behaviors: []func() (*fodcv1.InspectAllResponse, error){
+			returnError(codes.Unimplemented, "not supported"),
+		},
+	}
+	collector := newCollectorForFake(t, fake, 10*time.Minute)
+	ctx := t.Context()
+
+	data1, err := collector.Collect(ctx)
+	require.NoError(t, err)
+	assert.Nil(t, data1.Groups)
+	assert.True(t, collector.grpcUnimplemented.Load())
+
+	collector.mu.RLock()
+	require.NotNil(t, collector.currentData, "Unimplemented is a known terminal state and must be cached")
+	collector.mu.RUnlock()
+
+	data2, err := collector.Collect(ctx)
+	require.NoError(t, err)
+	assert.Same(t, data1, data2, "subsequent calls within TTL must hit cache")
+	assert.Equal(t, 1, fake.calls(), "Unimplemented must short-circuit subsequent RPCs")
 }

--- a/fodc/internal/timeouts/timeouts.go
+++ b/fodc/internal/timeouts/timeouts.go
@@ -1,0 +1,34 @@
+// Licensed to Apache Software Foundation (ASF) under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Apache Software Foundation (ASF) licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// Package timeouts holds timeout constants shared between the FODC agent and proxy.
+// Co-locating these constants ensures the proxy-side per-agent collection deadline is
+// always strictly greater than the agent-side InspectAll timeout, regardless of who
+// imports them.
+package timeouts
+
+import "time"
+
+// AgentInspectAll bounds how long a single InspectAll call against the local liaison
+// may run on the FODC agent side.
+const AgentInspectAll = 40 * time.Second
+
+// ProxySlack is the additional time the proxy waits, on top of AgentInspectAll, before
+// declaring an agent unresponsive. It must be strictly greater than zero so the proxy
+// always outlasts the agent's own deadline and never gives up while a slow but still
+// progressing InspectAll call is in flight.
+const ProxySlack = 10 * time.Second

--- a/fodc/proxy/internal/api/server.go
+++ b/fodc/proxy/internal/api/server.go
@@ -28,12 +28,24 @@ import (
 	"strings"
 	"time"
 
+	"google.golang.org/protobuf/encoding/protojson"
+
+	fodcv1 "github.com/apache/skywalking-banyandb/api/proto/banyandb/fodc/v1"
 	"github.com/apache/skywalking-banyandb/fodc/proxy/internal/cluster"
 	"github.com/apache/skywalking-banyandb/fodc/proxy/internal/lifecycle"
 	"github.com/apache/skywalking-banyandb/fodc/proxy/internal/metrics"
 	"github.com/apache/skywalking-banyandb/fodc/proxy/internal/registry"
 	"github.com/apache/skywalking-banyandb/pkg/logger"
 )
+
+// lifecycleGroupMarshaler emits zero-value protobuf fields (replicas=0, close=false, empty
+// stages, etc.) as explicit JSON keys instead of dropping them. The default encoding/json +
+// protoc-gen-go combination would silence those fields via `omitempty`, leaving downstream
+// consumers (SRE agent) unable to tell "field absent" from "value is zero".
+var lifecycleGroupMarshaler = protojson.MarshalOptions{
+	UseProtoNames:   true,
+	EmitUnpopulated: true,
+}
 
 // Server exposes REST and Prometheus-style endpoints for external consumption.
 type Server struct {
@@ -496,9 +508,23 @@ func (s *Server) handleClusterLifecycle(w http.ResponseWriter, r *http.Request) 
 	}
 	lifecycleData, agentSummary := s.lifecycleManager.CollectLifecycle(r.Context())
 
+	groupsJSON, err := marshalLifecycleGroups(lifecycleData.Groups)
+	if err != nil {
+		s.logger.Error().Err(err).Msg("Failed to marshal lifecycle groups")
+		http.Error(w, "Failed to serialize lifecycle groups", http.StatusInternalServerError)
+		return
+	}
+
+	statusesJSON, err := marshalLifecycleStatuses(lifecycleData.LifecycleStatuses)
+	if err != nil {
+		s.logger.Error().Err(err).Msg("Failed to marshal lifecycle statuses")
+		http.Error(w, "Failed to serialize lifecycle statuses", http.StatusInternalServerError)
+		return
+	}
+
 	body := map[string]interface{}{
-		"groups":             lifecycleData.Groups,
-		"lifecycle_statuses": lifecycleData.LifecycleStatuses,
+		"groups":             groupsJSON,
+		"lifecycle_statuses": statusesJSON,
 		"agent_summary":      agentSummary,
 	}
 	switch {
@@ -517,6 +543,42 @@ func (s *Server) handleClusterLifecycle(w http.ResponseWriter, r *http.Request) 
 	if encodeErr := json.NewEncoder(w).Encode(body); encodeErr != nil {
 		s.logger.Error().Err(encodeErr).Msg("Failed to encode lifecycle response")
 	}
+}
+
+func marshalLifecycleGroups(groups []*fodcv1.GroupLifecycleInfo) ([]json.RawMessage, error) {
+	out := make([]json.RawMessage, 0, len(groups))
+	for _, g := range groups {
+		raw, err := lifecycleGroupMarshaler.Marshal(g)
+		if err != nil {
+			return nil, fmt.Errorf("marshal group %q: %w", g.GetName(), err)
+		}
+		out = append(out, raw)
+	}
+	return out, nil
+}
+
+// lifecycleStatusJSON mirrors lifecycle.PodLifecycleStatus but holds each report as a
+// pre-marshaled protojson blob so the LifecycleReport's protobuf zero-value fields are
+// emitted consistently with the groups payload.
+type lifecycleStatusJSON struct {
+	PodName string            `json:"pod_name"`
+	Reports []json.RawMessage `json:"reports"`
+}
+
+func marshalLifecycleStatuses(statuses []*lifecycle.PodLifecycleStatus) ([]lifecycleStatusJSON, error) {
+	out := make([]lifecycleStatusJSON, 0, len(statuses))
+	for _, s := range statuses {
+		reports := make([]json.RawMessage, 0, len(s.Reports))
+		for _, r := range s.Reports {
+			raw, err := lifecycleGroupMarshaler.Marshal(r)
+			if err != nil {
+				return nil, fmt.Errorf("marshal report %q: %w", r.GetFilename(), err)
+			}
+			reports = append(reports, raw)
+		}
+		out = append(out, lifecycleStatusJSON{PodName: s.PodName, Reports: reports})
+	}
+	return out, nil
 }
 
 // handleClusterTopology handles GET /cluster/topology endpoint.

--- a/fodc/proxy/internal/api/server_test.go
+++ b/fodc/proxy/internal/api/server_test.go
@@ -833,3 +833,199 @@ func TestHandleClusterLifecycle_NoAgents_FlagsErrorInBody(t *testing.T) {
 	assert.EqualValues(t, 0, summary["total"], "agent_summary.total should be 0 when no agents are registered")
 	assert.EqualValues(t, 0, summary["responded"], "agent_summary.responded should be 0 when no agents are registered")
 }
+
+// runLifecycleHandlerWithGroup wires up a lifecycle manager backed by a single agent that
+// reports the supplied group, invokes the HTTP handler, and returns the parsed response
+// body so callers can inspect raw JSON keys.
+func runLifecycleHandlerWithGroup(t *testing.T, group *fodcv1.GroupLifecycleInfo) map[string]interface{} {
+	t.Helper()
+	initTestLogger(t)
+	testLogger := logger.GetLogger("test", "api")
+	testRegistry := registry.NewAgentRegistry(testLogger, 5*time.Second, 10*time.Second, 100)
+	t.Cleanup(testRegistry.Stop)
+	mockSender := &mockRequestSender{}
+	aggregator := metrics.NewAggregator(testRegistry, mockSender, testLogger)
+
+	mockLifecycleRequester := &mockLifecycleDataRequester{
+		dataByAgent: make(map[string]*fodcv1.LifecycleData),
+		podByAgent:  make(map[string]string),
+	}
+	lifecycleMgr := lifecycle.NewManager(testRegistry, mockLifecycleRequester, testLogger)
+	mockLifecycleRequester.lifecycleMgr = lifecycleMgr
+
+	identity := registry.AgentIdentity{
+		PodName:        "test-pod-1",
+		Role:           "datanode",
+		ContainerNames: []string{"banyandb"},
+	}
+	agentID, registerErr := testRegistry.RegisterAgent(context.Background(), identity)
+	require.NoError(t, registerErr)
+
+	mockLifecycleRequester.dataByAgent[agentID] = &fodcv1.LifecycleData{
+		Groups: []*fodcv1.GroupLifecycleInfo{group},
+	}
+	mockLifecycleRequester.podByAgent[agentID] = "test-pod-1"
+
+	server := NewServer(aggregator, nil, lifecycleMgr, testRegistry, testLogger)
+	req := httptest.NewRequest(http.MethodGet, "/cluster/lifecycle", nil)
+	resp := httptest.NewRecorder()
+	server.handleClusterLifecycle(resp, req)
+	require.Equal(t, http.StatusOK, resp.Code)
+
+	var body map[string]interface{}
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&body))
+	return body
+}
+
+// firstGroup pulls the first group from the decoded response body and asserts the basic shape.
+func firstGroup(t *testing.T, body map[string]interface{}) map[string]interface{} {
+	t.Helper()
+	groups, ok := body["groups"].([]interface{})
+	require.True(t, ok, "response body must contain a groups array")
+	require.NotEmpty(t, groups, "groups array must not be empty")
+	g, ok := groups[0].(map[string]interface{})
+	require.True(t, ok, "first group must decode to an object")
+	return g
+}
+
+func TestHandleClusterLifecycle_UsesSnakeCase(t *testing.T) {
+	group := &fodcv1.GroupLifecycleInfo{
+		Name: "g1",
+		ResourceOpts: &commonv1.ResourceOpts{
+			ShardNum: 4,
+		},
+	}
+	body := runLifecycleHandlerWithGroup(t, group)
+	g := firstGroup(t, body)
+
+	resourceOpts, ok := g["resource_opts"].(map[string]interface{})
+	require.True(t, ok, "field name must be snake_case 'resource_opts', not 'resourceOpts'")
+	assert.Equal(t, float64(4), resourceOpts["shard_num"], "field name must be snake_case 'shard_num'")
+	_, hasCamel := g["resourceOpts"]
+	assert.False(t, hasCamel, "camelCase key must not be emitted")
+}
+
+func TestHandleClusterLifecycle_EmitsZeroValueFields(t *testing.T) {
+	group := &fodcv1.GroupLifecycleInfo{
+		Name: "g1",
+		ResourceOpts: &commonv1.ResourceOpts{
+			ShardNum: 4,
+			Replicas: 0, // zero value must still appear in JSON output
+			Stages: []*commonv1.LifecycleStage{
+				{
+					Name:     "warm",
+					ShardNum: 2,
+					Close:    false, // zero value must still appear
+					Replicas: 0,     // zero value must still appear
+				},
+			},
+		},
+	}
+	body := runLifecycleHandlerWithGroup(t, group)
+	g := firstGroup(t, body)
+
+	resourceOpts := g["resource_opts"].(map[string]interface{})
+	_, hasReplicas := resourceOpts["replicas"]
+	assert.True(t, hasReplicas, "zero-value replicas at ResourceOpts level must be emitted, not omitted")
+	assert.Equal(t, float64(0), resourceOpts["replicas"])
+
+	stages, ok := resourceOpts["stages"].([]interface{})
+	require.True(t, ok)
+	require.Len(t, stages, 1)
+	stage := stages[0].(map[string]interface{})
+
+	_, hasClose := stage["close"]
+	assert.True(t, hasClose, "zero-value close=false in LifecycleStage must be emitted")
+	assert.Equal(t, false, stage["close"])
+
+	_, hasStageReplicas := stage["replicas"]
+	assert.True(t, hasStageReplicas, "zero-value replicas in LifecycleStage must be emitted")
+	assert.Equal(t, float64(0), stage["replicas"])
+}
+
+func TestHandleClusterLifecycle_NilResourceOptsIsNull(t *testing.T) {
+	group := &fodcv1.GroupLifecycleInfo{
+		Name: "g1",
+		// ResourceOpts intentionally nil
+	}
+	body := runLifecycleHandlerWithGroup(t, group)
+	g := firstGroup(t, body)
+
+	require.Contains(t, g, "resource_opts", "EmitUnpopulated must surface the absent message as a key")
+	assert.Nil(t, g["resource_opts"], "nil protobuf message marshals to JSON null under EmitUnpopulated")
+}
+
+func TestHandleClusterLifecycle_DataInfoEmitted(t *testing.T) {
+	group := &fodcv1.GroupLifecycleInfo{
+		Name: "g1",
+		DataInfo: []*databasev1.DataInfo{
+			{DataSizeBytes: 1024},
+		},
+	}
+	body := runLifecycleHandlerWithGroup(t, group)
+	g := firstGroup(t, body)
+
+	dataInfo, ok := g["data_info"].([]interface{})
+	require.True(t, ok, "data_info must be encoded as snake_case array")
+	require.Len(t, dataInfo, 1)
+}
+
+func TestHandleClusterLifecycle_StatusReportsUseProtoJSON(t *testing.T) {
+	initTestLogger(t)
+	testLogger := logger.GetLogger("test", "api")
+	testRegistry := registry.NewAgentRegistry(testLogger, 5*time.Second, 10*time.Second, 100)
+	t.Cleanup(testRegistry.Stop)
+	mockSender := &mockRequestSender{}
+	aggregator := metrics.NewAggregator(testRegistry, mockSender, testLogger)
+
+	mockLifecycleRequester := &mockLifecycleDataRequester{
+		dataByAgent: make(map[string]*fodcv1.LifecycleData),
+		podByAgent:  make(map[string]string),
+	}
+	lifecycleMgr := lifecycle.NewManager(testRegistry, mockLifecycleRequester, testLogger)
+	mockLifecycleRequester.lifecycleMgr = lifecycleMgr
+
+	identity := registry.AgentIdentity{
+		PodName:        "test-pod-1",
+		Role:           "datanode",
+		ContainerNames: []string{"banyandb"},
+	}
+	agentID, registerErr := testRegistry.RegisterAgent(context.Background(), identity)
+	require.NoError(t, registerErr)
+
+	mockLifecycleRequester.dataByAgent[agentID] = &fodcv1.LifecycleData{
+		Reports: []*fodcv1.LifecycleReport{
+			{Filename: "2026-04-29.json", ReportJson: `{"status":"ok"}`},
+			{Filename: "2026-04-28.json", ReportJson: ""}, // empty value must still be emitted
+		},
+	}
+	mockLifecycleRequester.podByAgent[agentID] = "test-pod-1"
+
+	server := NewServer(aggregator, nil, lifecycleMgr, testRegistry, testLogger)
+	req := httptest.NewRequest(http.MethodGet, "/cluster/lifecycle", nil)
+	resp := httptest.NewRecorder()
+	server.handleClusterLifecycle(resp, req)
+	require.Equal(t, http.StatusOK, resp.Code)
+
+	var body map[string]interface{}
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&body))
+
+	statuses, ok := body["lifecycle_statuses"].([]interface{})
+	require.True(t, ok)
+	require.Len(t, statuses, 1)
+	status := statuses[0].(map[string]interface{})
+	assert.Equal(t, "test-pod-1", status["pod_name"])
+
+	reports, ok := status["reports"].([]interface{})
+	require.True(t, ok)
+	require.Len(t, reports, 2)
+
+	first := reports[0].(map[string]interface{})
+	assert.Equal(t, "2026-04-29.json", first["filename"])
+	assert.Equal(t, `{"status":"ok"}`, first["report_json"], "field must be snake_case 'report_json'")
+
+	second := reports[1].(map[string]interface{})
+	_, hasReportJSON := second["report_json"]
+	assert.True(t, hasReportJSON, "empty report_json must still be emitted under EmitUnpopulated")
+	assert.Equal(t, "", second["report_json"])
+}

--- a/fodc/proxy/internal/lifecycle/manager.go
+++ b/fodc/proxy/internal/lifecycle/manager.go
@@ -21,14 +21,19 @@ package lifecycle
 import (
 	"context"
 	"sync"
-	"time"
 
 	fodcv1 "github.com/apache/skywalking-banyandb/api/proto/banyandb/fodc/v1"
+	"github.com/apache/skywalking-banyandb/fodc/internal/timeouts"
 	"github.com/apache/skywalking-banyandb/fodc/proxy/internal/registry"
 	"github.com/apache/skywalking-banyandb/pkg/logger"
 )
 
-const defaultCollectionTimeout = 10 * time.Second
+// defaultCollectionTimeout bounds how long the proxy waits for each agent to push back
+// its lifecycle data. It is derived from the agent-side InspectAll timeout plus a fixed
+// slack so that this deadline is strictly greater than the agent's own deadline; the
+// proxy must always outlast the agent and never give up while a still-progressing
+// InspectAll call is in flight on the agent side.
+const defaultCollectionTimeout = timeouts.AgentInspectAll + timeouts.ProxySlack
 
 // PodLifecycleStatus represents lifecycle status for a single pod.
 type PodLifecycleStatus struct {


### PR DESCRIPTION
Improves **liaison internal `queue_sub` chunked sync** observability and ties gauge lifecycle to session boundaries.

- **Saturation**: `chunked_sync_active_sessions` (by `topic`) increments on session start/switch and decrements via `releaseMetrics` on completion/switch/stream teardown to prevent leaks.  
- **Reorder backlog**: `chunk_reorder_buffered_chunks` (by `topic`) increments on buffer insert and decrements on draining buffered chunks; `releaseMetrics` reconciles any remaining buffered chunks.  
- **Completion outcomes**: On `handleCompletion`, records `chunked_sync_total_bytes_received` and `chunked_sync_duration_seconds`; failed parts use **`chunked_sync_failed_parts_total{topic}`** only (no `reason` label—avoids misleading breakdown without real per-part semantics).  
- **Chunk-ordering**: `buffer_timeout` is emitted from `checkBufferTimeout`, invoked **before** refreshing `lastActivity` in `processChunkWithReordering` so timeouts can actually fire.  
- **Refactor**: `startOrSwitchSession` / `cleanupPreviousSession` centralize session switching/cleanup; `SyncPart` defer consistently releases metric-held state.  
- **Tests**: Adds/adjusts unit tests to cover metrics wiring, buffer timeout behavior, and `reorderBuffered` interactions.

### <Feature description>
- [ ] If this is non-trivial feature, paste the links/URLs to the design doc.
- [ ] Update the documentation to include this new feature.
- [x] Tests(including UT, IT, E2E) are added to verify the new feature.
- [ ] If it's UI related, attach the screenshots below.

- [x] If this pull request closes/resolves/fixes an existing issue, replace the issue number. Fixes apache/skywalking#<issue number>.
- [ ] Update the [`CHANGES` log](https://github.com/apache/skywalking-banyandb/blob/main/CHANGES.md).
